### PR TITLE
Enhanced Azure Repos accounts and binding commands

### DIFF
--- a/src/Core.Tests/Authentication/MicrosoftAuthenticationTests.cs
+++ b/src/Core.Tests/Authentication/MicrosoftAuthenticationTests.cs
@@ -70,4 +70,69 @@ namespace GitCredentialManager.Tests.Authentication
             Assert.Throws<ArgumentException>(() => MicrosoftAuthentication.GetManagedIdentity(str));
         }
     }
+
+    public class MicrosoftAccountTests
+    {
+        [Theory]
+        // Classic Entra ID: two GUIDs
+        [InlineData("00000000-0000-0000-0000-000000000002.00000000-0000-0000-0000-000000000001")]
+        [InlineData("12345678-1234-1234-1234-123456789abc.fedcba98-7654-3210-fedc-ba9876543210")]
+        // Non-GUID object id; tenant id is still a GUID — split on LAST dot
+        [InlineData("contoso.onmicrosoft.com.00000000-0000-0000-0000-000000000001")]
+        [InlineData("b2c-policy.tenant.00000000-0000-0000-0000-000000000001")]
+        public void MicrosoftAccount_IsHomeAccountIdShape_ObjectIdAnyAndGuidTenantId_True(string value)
+        {
+            Assert.True(MicrosoftAccount.IsHomeAccountIdShape(value));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("alice@example.com")]
+        [InlineData("alice")]                                                                  // ADFS-shape / bare word
+        [InlineData("00000000-0000-0000-0000-000000000002")]                                   // single guid, no dot
+        [InlineData("00000000-0000-0000-0000-000000000002.")]                                  // trailing dot
+        [InlineData(".00000000-0000-0000-0000-000000000001")]                                  // leading dot
+        [InlineData("00000000-0000-0000-0000-000000000002.not-a-guid")]                        // tid is not a GUID
+        [InlineData("alice@example.com.contoso")]                                              // tid is not a GUID
+        public void MicrosoftAccount_IsHomeAccountIdShape_NotEntraHomeAccountId_False(string value)
+        {
+            Assert.False(MicrosoftAccount.IsHomeAccountIdShape(value));
+        }
+
+        [Fact]
+        public void MicrosoftAccount_FromIdentifier_HomeAccountIdShape_PopulatesHomeAccountId()
+        {
+            const string id = "00000000-0000-0000-0000-000000000002.00000000-0000-0000-0000-000000000001";
+
+            MicrosoftAccount account = MicrosoftAccount.FromIdentifier(id);
+
+            Assert.Equal(id, account.HomeAccountId);
+            Assert.Null(account.UserName);
+        }
+
+        [Theory]
+        [InlineData("alice@example.com")]
+        [InlineData("alice@contoso.onmicrosoft.com")]
+        [InlineData("alice")]                                  // ambiguous → UserName
+        [InlineData("contoso")]                                // ambiguous → UserName
+        [InlineData("00000000-0000-0000-0000-000000000002")]   // single guid, not HomeAccountId-shaped
+        public void MicrosoftAccount_FromIdentifier_NonHomeAccountIdShape_PopulatesUserName(string id)
+        {
+            MicrosoftAccount account = MicrosoftAccount.FromIdentifier(id);
+
+            Assert.Null(account.HomeAccountId);
+            Assert.Equal(id, account.UserName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void MicrosoftAccount_FromIdentifier_NullOrWhitespace_Throws(string id)
+        {
+            Assert.ThrowsAny<ArgumentException>(() => MicrosoftAccount.FromIdentifier(id));
+        }
+    }
 }

--- a/src/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/Core/Authentication/MicrosoftAuthentication.cs
@@ -183,6 +183,55 @@ namespace GitCredentialManager.Authentication
             return new MicrosoftAccount(msalAccount.HomeAccountId.Identifier, msalAccount.Username);
         }
 
+        /// <summary>
+        /// Construct an account from a single identifier whose shape isn't known by the caller
+        /// (typically supplied by the user via URL credential-helper input, the
+        /// <c>credential.username</c> git-config key, or a command-line argument). The identifier
+        /// is structurally classified and placed in the matching slot:
+        /// <list type="bullet">
+        ///   <item><description>An MSAL <see cref="HomeAccountId"/> shape
+        ///         (<c>&lt;object-id&gt;.&lt;tenant-id-guid&gt;</c>) is placed in
+        ///         <see cref="HomeAccountId"/>.</description></item>
+        ///   <item><description>Anything else is placed in <see cref="UserName"/>. This includes
+        ///         well-formed UPNs (<c>local@domain</c>), ADFS-style HomeAccountIds (which
+        ///         carry no tenant id and are indistinguishable from a bare username), and
+        ///         unrecognised values — MSAL's UPN-fallback resolution then either
+        ///         fuzzy-matches it or rejects it.</description></item>
+        /// </list>
+        /// The heuristics never reject an input. Throws <see cref="ArgumentException"/> only when
+        /// the identifier itself is null or whitespace.
+        /// </summary>
+        public static MicrosoftAccount FromIdentifier(string identifier)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(identifier, nameof(identifier));
+
+            return IsHomeAccountIdShape(identifier)
+                ? new MicrosoftAccount(homeAccountId: identifier, userName: null)
+                : new MicrosoftAccount(homeAccountId: null, userName: identifier);
+        }
+
+        /// <summary>
+        /// True when <paramref name="value"/> structurally matches an MSAL Microsoft Entra
+        /// <c>HomeAccountId</c>: an <c>&lt;object-id&gt;.&lt;tenant-id&gt;</c> pair where the
+        /// <c>tenant-id</c> suffix is a well-formed RFC 4122 GUID (a strong invariant for
+        /// Entra ID) and the <c>object-id</c> prefix is non-empty.
+        /// </summary>
+        /// <remarks>
+        /// Splits on the last <c>.</c> to mirror <c>Microsoft.Identity.Client.AccountId.ParseFromString</c>,
+        /// which permits an object id to itself contain dots in edge scenarios (B2C, some
+        /// guest accounts). Object ids are not required to be GUIDs; only the tenant id
+        /// is checked. Does not validate that the resulting pair refers to a real account,
+        /// and intentionally does not recognise the ADFS shape (single token, no dot) since
+        /// it is indistinguishable from a bare username.
+        /// </remarks>
+        public static bool IsHomeAccountIdShape(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return false;
+            int dot = value.LastIndexOf('.');
+            if (dot <= 0 || dot >= value.Length - 1) return false;
+            return Guid.TryParse(value.AsSpan(dot + 1), out _);
+        }
+
         public MicrosoftAccount(string homeAccountId, string userName)
         {
             UserName = userName;

--- a/src/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/Core/Authentication/MicrosoftAuthentication.cs
@@ -212,25 +212,6 @@ namespace GitCredentialManager.Authentication
         }
     }
 
-    public static class MicrosoftAuthenticationExtensions
-    {
-        /// <summary>
-        /// Convenience overload of <see cref="IMicrosoftAuthentication.GetTokenForUserAsync"/>
-        /// that takes a bare UPN string.
-        /// </summary>
-        [Obsolete("Construct a MicrosoftAccount and call the IMicrosoftAccount overload directly.")]
-        public static Task<IMicrosoftAuthenticationResult> GetTokenForUserAsync(
-            this IMicrosoftAuthentication msAuth,
-            string authority, string clientId, Uri redirectUri, string[] scopes, string userName, bool msaPt = false)
-        {
-            EnsureArgument.NotNull(msAuth, nameof(msAuth));
-            IMicrosoftAccount account = string.IsNullOrWhiteSpace(userName)
-                ? null
-                : new MicrosoftAccount(homeAccountId: null, userName: userName);
-            return msAuth.GetTokenForUserAsync(authority, clientId, redirectUri, scopes, account, msaPt);
-        }
-    }
-
     public class MicrosoftAuthentication : AuthenticationBase, IMicrosoftAuthentication
     {
         public static readonly string[] AuthorityIds =

--- a/src/Microsoft.AzureRepos.Tests/AzureReposBindingManagerTests.cs
+++ b/src/Microsoft.AzureRepos.Tests/AzureReposBindingManagerTests.cs
@@ -1,865 +1,339 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using GitCredentialManager;
+using GitCredentialManager.Authentication;
 using GitCredentialManager.Tests.Objects;
 using Xunit;
 
-namespace Microsoft.AzureRepos.Tests
+namespace Microsoft.AzureRepos.Tests;
+
+public class AzureReposBindingManagerTests
 {
-    public class AzureReposBindingManagerTests
+    private const string OrgName = "contoso";
+    private const string TenantId = "00000000-0000-0000-0000-000000000001";
+    private const string HomeAccountId = "00000000-0000-0000-0000-000000000002.00000000-0000-0000-0000-000000000001";
+    private const string UserName = "alice@example.com";
+
+    private static string OrgAccountIdKey() => $"credential.azrepos:org/{OrgName}.accountid";
+    private static string OrgUserNameKey()  => $"credential.azrepos:org/{OrgName}.username";
+    private static string TenantAccountIdKey() => $"credential.azrepos:tenant/{TenantId}.accountid";
+    private static string TenantUserNameKey()  => $"credential.azrepos:tenant/{TenantId}.username";
+
+    private static MicrosoftAccount Account(string hai = HomeAccountId, string upn = UserName) =>
+        new(hai, upn);
+
+    // -------- Bind --------
+
+    [Fact]
+    public void Bind_OrgGlobal_WithBothFields_WritesBothKeysAtGlobal()
     {
-        #region Bind
-
-        [Fact]
-        public void AzureReposBindingManager_Bind_NullOrganization_ThrowException()
-        {
-            var trace = new NullTrace();
-            var git = new TestGit();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            Assert.Throws<ArgumentNullException>(() => manager.Bind(null, "user", false));
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_Bind_NoUser_SetsOrgKey()
-        {
-            const string expectedUser = "user1";
-            const string orgName = "org";
-
-            var trace = new NullTrace();
-            var git = new TestGit();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            manager.Bind(orgName, expectedUser, false);
-
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var users));
-            Assert.Single(users);
-            string actualUser = users[0];
-            Assert.Equal(expectedUser, actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_BindLocal_NoUser_SetsOrgKey()
-        {
-            const string expectedUser = "user1";
-            const string orgName = "org";
-
-            var trace = new NullTrace();
-            var git = new TestGit();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            manager.Bind(orgName, expectedUser, true);
-
-            Assert.True(git.Configuration.Local.TryGetValue(CreateKey(orgName), out var users));
-            Assert.Single(users);
-            string actualUser = users[0];
-            Assert.Equal(expectedUser, actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_Bind_ExistingUser_SetsOrgKey()
-        {
-            const string expectedUser = "user1";
-            const string orgName = "org";
-
-            var trace = new NullTrace();
-            var git = new TestGit();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new[] {"org-user"};
-
-            manager.Bind(orgName, expectedUser, false);
-
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var users));
-            Assert.Single(users);
-            string actualUser = users[0];
-            Assert.Equal(expectedUser, actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_BindLocal_ExistingUser_SetsOrgKey()
-        {
-            const string expectedUser = "user1";
-            const string orgName = "org";
-
-            var trace = new NullTrace();
-            var git = new TestGit();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Local[CreateKey(orgName)] = new[] {"org-user"};
-
-            manager.Bind(orgName, expectedUser, true);
-
-            Assert.True(git.Configuration.Local.TryGetValue(CreateKey(orgName), out var users));
-            Assert.Single(users);
-            string actualUser = users[0];
-            Assert.Equal(expectedUser, actualUser);
-        }
-
-        #endregion
-
-        #region Unbind
-
-        [Fact]
-        public void AzureReposBindingManager_Unbind_NullOrganization_ThrowException()
-        {
-            var trace = new NullTrace();
-            var git = new TestGit();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            Assert.Throws<ArgumentNullException>(() => manager.Unbind(null, false));
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_Unbind_NoUser_DoesNothing()
-        {
-            const string orgName = "org";
-
-            var trace = new NullTrace();
-            var git = new TestGit();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            manager.Unbind(orgName, false);
-
-            Assert.Empty(git.Configuration.Global);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_UnbindLocal_NoUser_DoesNothing()
-        {
-            const string orgName = "org";
-
-            var trace = new NullTrace();
-            var git = new TestGit();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            manager.Unbind(orgName, true);
-
-            Assert.Empty(git.Configuration.Local);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_Unbind_ExistingUser_RemovesKey()
-        {
-            const string orgName = "org";
-
-            var trace = new NullTrace();
-            var git = new TestGit();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new[] {"org-user"};
-
-            manager.Unbind(orgName, false);
-
-            Assert.Empty(git.Configuration.Global);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_UnbindLocal_ExistingUser_RemovesKey()
-        {
-            const string orgName = "org";
-
-            var trace = new NullTrace();
-            var git = new TestGit();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Local[CreateKey(orgName)] = new[] {"org-user"};
-
-            manager.Unbind(orgName, true);
-
-            Assert.Empty(git.Configuration.Local);
-        }
-
-        #endregion
-
-        #region GetBinding
-
-        [Fact]
-        public void AzureReposBindingManager_GetBinding_Null_ThrowException()
-        {
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            Assert.Throws<ArgumentNullException>(() => manager.GetBinding(null));
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_GetBinding_NoUser_ReturnsNull()
-        {
-            const string orgName = "org";
-
-            var trace = new NullTrace();
-            var git = new TestGit();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            AzureReposBinding binding = manager.GetBinding(orgName);
-
-            Assert.Null(binding);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_GetBinding_GlobalUser_ReturnsBinding()
-        {
-            const string orgUser = "john.doe";
-            const string orgName = "org";
-            string orgKey = CreateKey(orgName);
-
-            var git = new TestGit
-            {
-                Configuration =
-                {
-                    Global =
-                    {
-                        [orgKey] = new[] {orgUser}
-                    }
-                }
-            };
-
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            AzureReposBinding binding = manager.GetBinding(orgName);
-
-            Assert.Equal(orgName, binding.Organization);
-            Assert.Equal(orgUser, binding.GlobalUserName);
-            Assert.Null(binding.LocalUserName);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_GetBinding_LocalUser_ReturnsBinding()
-        {
-            const string orgUser = "john.doe";
-            const string orgName = "org";
-            string orgKey = CreateKey(orgName);
-
-            var git = new TestGit
-            {
-                Configuration =
-                {
-                    Local =
-                    {
-                        [orgKey] = new[] {orgUser}
-                    }
-                }
-            };
-
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            AzureReposBinding binding = manager.GetBinding(orgName);
-
-            Assert.Equal(orgName, binding.Organization);
-            Assert.Null(binding.GlobalUserName);
-            Assert.Equal(orgUser, binding.LocalUserName);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_GetBinding_LocalAndGlobalUsers_ReturnsBinding()
-        {
-            const string orgUserLocal = "john.doe";
-            const string orgUserGlobal = "jane.doe";
-            const string orgName = "org";
-            string orgKey = CreateKey(orgName);
-
-            var git = new TestGit
-            {
-                Configuration =
-                {
-                    Global = { [orgKey] = new[] {orgUserGlobal} },
-                    Local  = { [orgKey] = new[] {orgUserLocal} }
-                }
-            };
-
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            AzureReposBinding binding = manager.GetBinding(orgName);
-
-            Assert.Equal(orgName, binding.Organization);
-            Assert.Equal(orgUserGlobal, binding.GlobalUserName);
-            Assert.Equal(orgUserLocal, binding.LocalUserName);
-        }
-
-        #endregion
-
-        #region GetBindings
-
-        [Fact]
-        public void AzureReposBindingManager_GetBindings_NoUsers_ReturnsEmpty()
-        {
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            IList<AzureReposBinding> actual = manager.GetBindings().ToList();
-
-            Assert.Empty(actual);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_GetBindings_Users_ReturnsUsers()
-        {
-            const string org1 = "org1";
-            const string org2 = "org2";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(org1)] = new[] {"user1"};
-            git.Configuration.Global[CreateKey(org2)] = new[] {"user2"};
-
-            AzureReposBinding[] bindings = manager.GetBindings().ToArray();
-
-            static void AssertBinding(
-                string expectedOrg, string expectedGlobalUser, string expectedLocalUser, AzureReposBinding binding)
-            {
-                Assert.Equal(expectedOrg, binding.Organization);
-                Assert.Equal(expectedGlobalUser, binding.GlobalUserName);
-                Assert.Equal(expectedLocalUser, binding.LocalUserName);
-            }
-
-            Assert.Equal(2, bindings.Length);
-            AssertBinding(org1, "user1", null, bindings[0]);
-            AssertBinding(org2, "user2", null, bindings[1]);
-        }
-
-        #endregion
-
-        #region GetUser
-
-        [Fact]
-        public void AzureReposBindingManager_GetUser_NullOrg_ThrowsException()
-        {
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            Assert.Throws<ArgumentNullException>(() => manager.GetUser(null));
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_GetUser_NoUser_ReturnsNull()
-        {
-            const string orgName = "org";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            string actualUser = manager.GetUser(orgName);
-
-            Assert.Null(actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_GetUser_GlobalUser_ReturnsGlobalUser()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new[] {user1};
-
-            string actualUser = manager.GetUser(orgName);
-
-            Assert.Equal(user1, actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_GetUser_LocalUser_ReturnsLocalUser()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Local[CreateKey(orgName)] = new[] {user1};
-
-            string actualUser = manager.GetUser(orgName);
-
-            Assert.Equal(user1, actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_GetUser_GlobalAndLocalUsers_ReturnsLocalUser()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-            const string user2 = "user2";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new[] {user1};
-            git.Configuration.Local[CreateKey(orgName)] = new[] {user2};
-
-            string actualUser = manager.GetUser(orgName);
-
-            Assert.Equal(user2, actualUser);
-        }
-
-        #endregion
-
-        #region SignIn
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_NullOrg_ThrowsException()
-        {
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            Assert.Throws<ArgumentNullException>(() => manager.SignIn(null, "user1"));
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_NullUser_ThrowsException()
-        {
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            Assert.Throws<ArgumentNullException>(() => manager.SignIn("org", null));
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_NoGlobalNoLocal_BindsGlobal()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            manager.SignIn(orgName, user1);
-
-            Assert.Empty(git.Configuration.Local);
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            string actualUser = globalUsers[0];
-            Assert.Equal(user1, actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_NoGlobalSameLocal_BindsGlobalUnbindLocal()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Local[CreateKey(orgName)] = new []{user1};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.Empty(git.Configuration.Local);
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            string actualUser = globalUsers[0];
-            Assert.Equal(user1, actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_NoGlobalOtherLocal_BindsGlobalUnbindLocal()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-            const string user2 = "user2";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Local[CreateKey(orgName)] = new []{user2};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.Empty(git.Configuration.Local);
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            string actualUser = globalUsers[0];
-            Assert.Equal(user1, actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_SameGlobalNoLocal_DoesNothing()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new []{user1};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.Empty(git.Configuration.Local);
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            string actualUser = globalUsers[0];
-            Assert.Equal(user1, actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_SameGlobalSameLocal_UnbindLocal()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new []{user1};
-            git.Configuration.Local[CreateKey(orgName)] = new []{user1};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.Empty(git.Configuration.Local);
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            string actualUser = globalUsers[0];
-            Assert.Equal(user1, actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_SameGlobalOtherLocal_UnbindLocal()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-            const string user2 = "user2";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new []{user1};
-            git.Configuration.Local[CreateKey(orgName)] = new []{user2};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.Empty(git.Configuration.Local);
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            string actualUser = globalUsers[0];
-            Assert.Equal(user1, actualUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_OtherGlobalNoLocal_BindsLocal()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-            const string user2 = "user2";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new []{user2};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.True(git.Configuration.Local.TryGetValue(CreateKey(orgName), out var localUsers));
-            string actualLocalUser = localUsers[0];
-            Assert.Equal(user1, actualLocalUser);
-
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            string actualGlobalUser = globalUsers[0];
-            Assert.Equal(user2, actualGlobalUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_OtherGlobalSameLocal_DoesNothing()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-            const string user2 = "user2";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new []{user2};
-            git.Configuration.Local[CreateKey(orgName)] = new []{user1};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.True(git.Configuration.Local.TryGetValue(CreateKey(orgName), out var localUsers));
-            string actualLocalUser = localUsers[0];
-            Assert.Equal(user1, actualLocalUser);
-
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            string actualGlobalUser = globalUsers[0];
-            Assert.Equal(user2, actualGlobalUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_OtherGlobalOtherLocal_BindsLocal()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-            const string user2 = "user2";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new []{user2};
-            git.Configuration.Local[CreateKey(orgName)] = new []{user2};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.True(git.Configuration.Local.TryGetValue(CreateKey(orgName), out var localUsers));
-            string actualLocalUser = localUsers[0];
-            Assert.Equal(user1, actualLocalUser);
-
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            string actualGlobalUser = globalUsers[0];
-            Assert.Equal(user2, actualGlobalUser);
-        }
-
-        // Idempotency: SignIn when state is already correct should not write to git config
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_SameGlobalNoLocal_NoConfigWrites()
-        {
-            // Steady-state: global already bound to signing-in user, no local override.
-            // This is the common case on every 'git fetch' after the first sign-in.
-            const string orgName = "org";
-            const string user1 = "user1";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new[] {user1};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.Equal(0, git.Configuration.SetCallCount);
-            Assert.Equal(0, git.Configuration.UnsetCallCount);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_OtherGlobalSameLocal_NoConfigWrites()
-        {
-            // Steady-state: a different user holds the global binding, and local is already
-            // bound to the signing-in user. No change needed.
-            const string orgName = "org";
-            const string user1 = "user1";
-            const string user2 = "user2";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new[] {user2};
-            git.Configuration.Local[CreateKey(orgName)] = new[] {user1};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.Equal(0, git.Configuration.SetCallCount);
-            Assert.Equal(0, git.Configuration.UnsetCallCount);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_SameGlobalSameLocal_OnlyUnbindsLocal()
-        {
-            // Global already matches, local redundantly mirrors it.
-            // Only the local unset is needed; re-writing the global value is wasteful.
-            const string orgName = "org";
-            const string user1 = "user1";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new[] {user1};
-            git.Configuration.Local[CreateKey(orgName)] = new[] {user1};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.Equal(0, git.Configuration.SetCallCount);
-            Assert.Equal(1, git.Configuration.UnsetCallCount);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignIn_SameGlobalOtherLocal_OnlyUnbindsLocal()
-        {
-            // Global already matches, local has a different user that needs removing.
-            // Only the local unset is needed; re-writing the global value is wasteful.
-            const string orgName = "org";
-            const string user1 = "user1";
-            const string user2 = "user2";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new[] {user1};
-            git.Configuration.Local[CreateKey(orgName)] = new[] {user2};
-
-            manager.SignIn(orgName, user1);
-
-            Assert.Equal(0, git.Configuration.SetCallCount);
-            Assert.Equal(1, git.Configuration.UnsetCallCount);
-        }
-
-        #endregion
-
-        #region SignOut
-
-        [Fact]
-        public void AzureReposBindingManager_SignOut_NoGlobalNoLocal_DoesNothing()
-        {
-            const string orgName = "org";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            manager.SignOut(orgName);
-
-            Assert.Empty(git.Configuration.Local);
-            Assert.Empty(git.Configuration.Global);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignOut_NoGlobalUserLocal_UnbindsLocal()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Local[CreateKey(orgName)] = new[] { user1 };
-
-            manager.SignOut(orgName);
-
-            Assert.Empty(git.Configuration.Local);
-            Assert.Empty(git.Configuration.Global);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignOut_NoGlobalNoInheritLocal_UnbindsLocal()
-        {
-            const string orgName = "org";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Local[CreateKey(orgName)] = new[] { AzureReposBinding.NoInherit };
-
-            manager.SignOut(orgName);
-
-            Assert.Empty(git.Configuration.Global);
-            Assert.Empty(git.Configuration.Local);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignOut_UserGlobalNoLocal_BindLocalNoInherit()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new[] { user1 };
-
-            manager.SignOut(orgName);
-
-            Assert.True(git.Configuration.Local.TryGetValue(CreateKey(orgName), out var localUsers));
-            Assert.Single(localUsers);
-            string actualLocalUser = localUsers[0];
-            Assert.Equal(AzureReposBinding.NoInherit, actualLocalUser);
-
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            Assert.Single(globalUsers);
-            string actualGlobalUser = globalUsers[0];
-            Assert.Equal(user1, actualGlobalUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignOut_UserGlobalNoInheritLocal_DoesNothing()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new[] { user1 };
-            git.Configuration.Local[CreateKey(orgName)] = new[] { AzureReposBinding.NoInherit };
-
-            manager.SignOut(orgName);
-
-            Assert.True(git.Configuration.Local.TryGetValue(CreateKey(orgName), out var localUsers));
-            Assert.Single(localUsers);
-            string actualLocalUser = localUsers[0];
-            Assert.Equal(AzureReposBinding.NoInherit, actualLocalUser);
-
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            Assert.Single(globalUsers);
-            string actualGlobalUser = globalUsers[0];
-            Assert.Equal(user1, actualGlobalUser);
-        }
-
-        [Fact]
-        public void AzureReposBindingManager_SignOut_UserGlobalUserLocal_BindLocalNoInherit()
-        {
-            const string orgName = "org";
-            const string user1 = "user1";
-            const string user2 = "user2";
-
-            var git = new TestGit();
-            var trace = new NullTrace();
-            var manager = new AzureReposBindingManager(trace, git);
-
-            git.Configuration.Global[CreateKey(orgName)] = new[] { user1 };
-            git.Configuration.Local[CreateKey(orgName)] = new[] { user2 };
-
-            manager.SignOut(orgName);
-
-            Assert.True(git.Configuration.Local.TryGetValue(CreateKey(orgName), out var localUsers));
-            Assert.Single(localUsers);
-            string actualLocalUser = localUsers[0];
-            Assert.Equal(AzureReposBinding.NoInherit, actualLocalUser);
-
-            Assert.True(git.Configuration.Global.TryGetValue(CreateKey(orgName), out var globalUsers));
-            Assert.Single(globalUsers);
-            string actualGlobalUser = globalUsers[0];
-            Assert.Equal(user1, actualGlobalUser);
-        }
-
-
-        #endregion
-
-        #region Helpers
-
-        private static string CreateKey(string orgName)
-        {
-            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}:{2}/{3}.{4}",
-                Constants.GitConfiguration.Credential.SectionName,
-                AzureDevOpsConstants.UrnScheme, AzureDevOpsConstants.UrnOrgPrefix, orgName,
-                Constants.GitConfiguration.Credential.UserName);
-        }
-
-        #endregion
+        var git = new TestGit();
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        manager.Bind(AzureReposBindingScope.ForOrg(OrgName), Account());
+
+        Assert.Equal(HomeAccountId, git.Configuration.Global[OrgAccountIdKey()].Single());
+        Assert.Equal(UserName,      git.Configuration.Global[OrgUserNameKey()].Single());
+        Assert.False(git.Configuration.Local.ContainsKey(OrgAccountIdKey()));
+        Assert.False(git.Configuration.Local.ContainsKey(OrgUserNameKey()));
+    }
+
+    [Fact]
+    public void Bind_HomeAccountIdOnly_WritesAccountIdAndClearsUserName()
+    {
+        var git = new TestGit();
+        git.Configuration.Global[OrgUserNameKey()] = new List<string> { "stale@example.com" };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        manager.Bind(AzureReposBindingScope.ForOrg(OrgName), Account(upn: null));
+
+        Assert.Equal(HomeAccountId, git.Configuration.Global[OrgAccountIdKey()].Single());
+        Assert.False(git.Configuration.Global.ContainsKey(OrgUserNameKey()));
+    }
+
+    [Fact]
+    public void Bind_UserNameOnly_WritesUserNameAndClearsAccountId()
+    {
+        var git = new TestGit();
+        git.Configuration.Global[OrgAccountIdKey()] = new List<string> { "stale-id" };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        manager.Bind(AzureReposBindingScope.ForOrg(OrgName), Account(hai: null));
+
+        Assert.Equal(UserName, git.Configuration.Global[OrgUserNameKey()].Single());
+        Assert.False(git.Configuration.Global.ContainsKey(OrgAccountIdKey()));
+    }
+
+    [Fact]
+    public void Bind_NeitherField_Throws()
+    {
+        var git = new TestGit();
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        Assert.Throws<ArgumentException>(() =>
+            manager.Bind(AzureReposBindingScope.ForOrg(OrgName), new MicrosoftAccount(null, null)));
+    }
+
+    [Fact]
+    public void Bind_OrgLocal_WritesAtLocal()
+    {
+        var git = new TestGit();
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        manager.Bind(AzureReposBindingScope.ForOrg(OrgName, isLocal: true), Account());
+
+        Assert.Equal(HomeAccountId, git.Configuration.Local[OrgAccountIdKey()].Single());
+        Assert.False(git.Configuration.Global.ContainsKey(OrgAccountIdKey()));
+    }
+
+    [Fact]
+    public void Bind_TenantGlobal_WritesAtGlobal()
+    {
+        var git = new TestGit();
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        manager.Bind(AzureReposBindingScope.ForTenant(TenantId), Account());
+
+        Assert.Equal(HomeAccountId, git.Configuration.Global[TenantAccountIdKey()].Single());
+        Assert.Equal(UserName,      git.Configuration.Global[TenantUserNameKey()].Single());
+    }
+
+    [Fact]
+    public void Bind_LocalScope_OutsideRepository_DoesNothing()
+    {
+        var git = new TestGit(insideRepo: false);
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        manager.Bind(AzureReposBindingScope.ForOrg(OrgName, isLocal: true), Account());
+
+        Assert.False(git.Configuration.Local.ContainsKey(OrgAccountIdKey()));
+        Assert.False(git.Configuration.Local.ContainsKey(OrgUserNameKey()));
+    }
+
+    // -------- Unbind --------
+
+    [Fact]
+    public void Unbind_OrgGlobal_RemovesBothKeysAtGlobalOnly()
+    {
+        var git = new TestGit();
+        git.Configuration.Global[OrgAccountIdKey()] = new List<string> { HomeAccountId };
+        git.Configuration.Global[OrgUserNameKey()]  = new List<string> { UserName };
+        git.Configuration.Local[OrgAccountIdKey()]  = new List<string> { HomeAccountId };
+        git.Configuration.Local[OrgUserNameKey()]   = new List<string> { UserName };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        manager.Unbind(AzureReposBindingScope.ForOrg(OrgName));
+
+        Assert.False(git.Configuration.Global.ContainsKey(OrgAccountIdKey()));
+        Assert.False(git.Configuration.Global.ContainsKey(OrgUserNameKey()));
+        Assert.True(git.Configuration.Local.ContainsKey(OrgAccountIdKey()));
+        Assert.True(git.Configuration.Local.ContainsKey(OrgUserNameKey()));
+    }
+
+    [Fact]
+    public void Unbind_LocalScope_OutsideRepository_DoesNothing()
+    {
+        var git = new TestGit(insideRepo: false);
+        git.Configuration.Local[OrgAccountIdKey()] = new List<string> { HomeAccountId };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        manager.Unbind(AzureReposBindingScope.ForOrg(OrgName, isLocal: true));
+
+        Assert.True(git.Configuration.Local.ContainsKey(OrgAccountIdKey()));
+    }
+
+    // -------- GetAccount --------
+
+    [Fact]
+    public void GetAccount_BothKeys_ReturnsBothFields()
+    {
+        var git = new TestGit();
+        git.Configuration.Global[OrgAccountIdKey()] = new List<string> { HomeAccountId };
+        git.Configuration.Global[OrgUserNameKey()]  = new List<string> { UserName };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        IMicrosoftAccount account = manager.GetAccount(AzureReposBindingScope.ForOrg(OrgName));
+
+        Assert.NotNull(account);
+        Assert.Equal(HomeAccountId, account.HomeAccountId);
+        Assert.Equal(UserName,      account.UserName);
+    }
+
+    [Fact]
+    public void GetAccount_AccountIdOnly_ReturnsHomeAccountIdField()
+    {
+        var git = new TestGit();
+        git.Configuration.Global[OrgAccountIdKey()] = new List<string> { HomeAccountId };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        IMicrosoftAccount account = manager.GetAccount(AzureReposBindingScope.ForOrg(OrgName));
+
+        Assert.NotNull(account);
+        Assert.Equal(HomeAccountId, account.HomeAccountId);
+        Assert.Null(account.UserName);
+    }
+
+    [Fact]
+    public void GetAccount_UserNameOnly_ReturnsUserNameField()
+    {
+        // Both legacy `.username`-only and new UPN-only bindings read the same way.
+        var git = new TestGit();
+        git.Configuration.Global[OrgUserNameKey()] = new List<string> { UserName };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        IMicrosoftAccount account = manager.GetAccount(AzureReposBindingScope.ForOrg(OrgName));
+
+        Assert.NotNull(account);
+        Assert.Null(account.HomeAccountId);
+        Assert.Equal(UserName, account.UserName);
+    }
+
+    [Fact]
+    public void GetAccount_TenantWithUserNameOnly_FallsBack()
+    {
+        // Tenant scope didn't exist before the rewrite, so this case only ever arises from
+        // a user editing git config by hand — but the read path treats it symmetrically.
+        var git = new TestGit();
+        git.Configuration.Global[TenantUserNameKey()] = new List<string> { UserName };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        IMicrosoftAccount account = manager.GetAccount(AzureReposBindingScope.ForTenant(TenantId));
+
+        Assert.NotNull(account);
+        Assert.Equal(UserName, account.UserName);
+    }
+
+    [Fact]
+    public void GetAccount_NoEntry_ReturnsNull()
+    {
+        var git = new TestGit();
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        Assert.Null(manager.GetAccount(AzureReposBindingScope.ForOrg(OrgName)));
+        Assert.Null(manager.GetAccount(AzureReposBindingScope.ForTenant(TenantId)));
+    }
+
+    [Fact]
+    public void GetAccount_LocalScope_OutsideRepository_ReturnsNull()
+    {
+        var git = new TestGit(insideRepo: false);
+        git.Configuration.Local[OrgAccountIdKey()] = new List<string> { HomeAccountId };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        Assert.Null(manager.GetAccount(AzureReposBindingScope.ForOrg(OrgName, isLocal: true)));
+    }
+
+    // -------- GetBindings --------
+
+    [Fact]
+    public void GetBindings_EnumeratesEveryStoredBinding()
+    {
+        var git = new TestGit();
+        git.Configuration.Global[OrgAccountIdKey()]    = new List<string> { HomeAccountId };
+        git.Configuration.Global[OrgUserNameKey()]     = new List<string> { UserName };
+        git.Configuration.Global[TenantAccountIdKey()] = new List<string> { "tenant-id" };
+        git.Configuration.Local[OrgUserNameKey()]      = new List<string> { "local-only@example.com" };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        List<AzureReposBinding> bindings = manager.GetBindings().ToList();
+
+        Assert.Equal(3, bindings.Count);
+        Assert.Contains(bindings, b =>
+            b.Scope is AzureReposBindingScope.Org { OrgName: OrgName, IsLocal: false } &&
+            b.Account.HomeAccountId == HomeAccountId && b.Account.UserName == UserName);
+        Assert.Contains(bindings, b =>
+            b.Scope is AzureReposBindingScope.Tenant { TenantId: TenantId, IsLocal: false } &&
+            b.Account.HomeAccountId == "tenant-id" && b.Account.UserName is null);
+        Assert.Contains(bindings, b =>
+            b.Scope is AzureReposBindingScope.Org { OrgName: OrgName, IsLocal: true } &&
+            b.Account.HomeAccountId is null && b.Account.UserName == "local-only@example.com");
+    }
+
+    [Fact]
+    public void GetBindings_OutsideRepository_SkipsLocalEntries()
+    {
+        var git = new TestGit(insideRepo: false);
+        git.Configuration.Global[OrgAccountIdKey()] = new List<string> { HomeAccountId };
+        git.Configuration.Local[OrgAccountIdKey()]  = new List<string> { "ignored" };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        List<AzureReposBinding> bindings = manager.GetBindings().ToList();
+
+        Assert.Single(bindings);
+        Assert.False(bindings[0].Scope.IsLocal);
+    }
+
+    // -------- ResolveAccountBinding (extension) --------
+
+    [Fact]
+    public void ResolveAccountBinding_PrefersLocalOrgOverGlobalOrg()
+    {
+        var git = new TestGit();
+        git.Configuration.Global[OrgAccountIdKey()] = new List<string> { HomeAccountId };
+        git.Configuration.Local[OrgAccountIdKey()]  = new List<string> { "local-id" };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        IMicrosoftAccount resolved = manager.ResolveAccountBinding(OrgName, tenantId: null);
+
+        Assert.Equal("local-id", resolved.HomeAccountId);
+    }
+
+    [Fact]
+    public void ResolveAccountBinding_FallsBackToGlobalWhenNoLocal()
+    {
+        var git = new TestGit();
+        git.Configuration.Global[OrgAccountIdKey()] = new List<string> { HomeAccountId };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        IMicrosoftAccount resolved = manager.ResolveAccountBinding(OrgName, tenantId: null);
+
+        Assert.Equal(HomeAccountId, resolved.HomeAccountId);
+    }
+
+    [Fact]
+    public void ResolveAccountBinding_FallsBackToTenantWhenNoOrgBinding()
+    {
+        var git = new TestGit();
+        git.Configuration.Global[TenantAccountIdKey()] = new List<string> { "tenant-id" };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        IMicrosoftAccount resolved = manager.ResolveAccountBinding(OrgName, TenantId);
+
+        Assert.Equal("tenant-id", resolved.HomeAccountId);
+    }
+
+    [Fact]
+    public void ResolveAccountBinding_OrgWinsOverTenant()
+    {
+        var git = new TestGit();
+        git.Configuration.Global[OrgAccountIdKey()]    = new List<string> { HomeAccountId };
+        git.Configuration.Global[TenantAccountIdKey()] = new List<string> { "tenant-id" };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        IMicrosoftAccount resolved = manager.ResolveAccountBinding(OrgName, TenantId);
+
+        Assert.Equal(HomeAccountId, resolved.HomeAccountId);
+    }
+
+    [Fact]
+    public void ResolveAccountBinding_LocalTenantWinsOverGlobalTenant()
+    {
+        var git = new TestGit();
+        git.Configuration.Global[TenantAccountIdKey()] = new List<string> { "global-tenant" };
+        git.Configuration.Local[TenantAccountIdKey()]  = new List<string> { "local-tenant" };
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        IMicrosoftAccount resolved = manager.ResolveAccountBinding(OrgName, TenantId);
+
+        Assert.Equal("local-tenant", resolved.HomeAccountId);
+    }
+
+    [Fact]
+    public void ResolveAccountBinding_NoMatch_ReturnsNull()
+    {
+        var git = new TestGit();
+        var manager = new AzureReposBindingManager(new NullTrace(), git);
+
+        Assert.Null(manager.ResolveAccountBinding(OrgName, TenantId));
     }
 }

--- a/src/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
+++ b/src/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AzureRepos.Tests
         [Fact]
         public async Task AzureReposProvider_GetCredentialAsync_JwtMode_CachedAuthority_VsComUrlUser_ReturnsCredential()
         {
-            var urlAccount = "jane.doe";
+            var urlAccount = "jane.doe@contoso.com";
 
             var request = new GitRequest(new Dictionary<string, string>
             {
@@ -192,7 +192,7 @@ namespace Microsoft.AzureRepos.Tests
         [Fact]
         public async Task AzureReposProvider_GetCredentialAsync_JwtMode_CachedAuthority_DevAzureUrlUser_ReturnsCredential()
         {
-            var urlAccount = "jane.doe";
+            var urlAccount = "jane.doe@contoso.com";
 
             var request = new GitRequest(new Dictionary<string, string>
             {
@@ -241,6 +241,60 @@ namespace Microsoft.AzureRepos.Tests
         }
 
         [Fact]
+        public async Task AzureReposProvider_GetCredentialAsync_JwtMode_CachedAuthority_DevAzureUrlHomeAccountId_ReturnsCredential()
+        {
+            // A user can pin a clone to a specific MSAL account by embedding its HomeAccountId
+            // in the URL/credential.username. `MicrosoftAccount.FromIdentifier` routes the
+            // GUID-dot-GUID value into the HomeAccountId slot rather than the UPN slot so msauth
+            // resolves it correctly.
+            var urlAccount = "00000000-0000-0000-0000-000000000002.00000000-0000-0000-0000-000000000001";
+
+            var request = new GitRequest(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "dev.azure.com",
+                ["path"] = "org/project/_git/repo",
+                ["username"] = urlAccount
+            });
+
+            var expectedOrgUri = new Uri("https://dev.azure.com/org");
+            var authorityUrl = "https://login.microsoftonline.com/common";
+            var expectedClientId = AzureDevOpsConstants.AadClientId;
+            var expectedRedirectUri = AzureDevOpsConstants.AadRedirectUri;
+            var expectedScopes = AzureDevOpsConstants.AzureDevOpsDefaultScopes;
+            var accessToken = "ACCESS-TOKEN";
+            var resolvedUpn = "jane.doe@contoso.com";
+            var expectedAccount = new MicrosoftAccount(homeAccountId: urlAccount, userName: null);
+            var authResult = CreateAuthResult(resolvedUpn, accessToken);
+
+            var context = new TestCommandContext();
+
+            context.Environment.Variables[AzureDevOpsConstants.EnvironmentVariables.CredentialType] =
+                AzureDevOpsConstants.OAuthCredentialType;
+
+            var azDevOpsMock = new Mock<IAzureDevOpsRestApi>(MockBehavior.Strict);
+            azDevOpsMock.Setup(x => x.GetAuthorityAsync(expectedOrgUri)).ReturnsAsync(authorityUrl);
+
+            var msAuthMock = new Mock<IMicrosoftAuthentication>(MockBehavior.Strict);
+            msAuthMock.Setup(x => x.GetTokenForUserAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, expectedAccount, true))
+                      .ReturnsAsync(authResult);
+
+            var authorityCacheMock = new Mock<IAzureDevOpsAuthorityCache>(MockBehavior.Strict);
+            authorityCacheMock.Setup(x => x.GetAuthority(OrgName)).Returns(authorityUrl);
+
+            var userMgrMock = new Mock<IAzureReposBindingManager>(MockBehavior.Strict);
+
+            var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCacheMock.Object, userMgrMock.Object);
+
+            var result = await provider.GetCredentialAsync(request);
+            ICredential credential = result.Credential;
+
+            Assert.NotNull(credential);
+            Assert.Equal(resolvedUpn, credential.Account);
+            Assert.Equal(accessToken, credential.Password);
+        }
+
+        [Fact]
         public async Task AzureReposProvider_GetCredentialAsync_JwtMode_CachedAuthority_DevAzureUrlOrgName_ReturnsCredential()
         {
             var request = new GitRequest(new Dictionary<string, string>
@@ -277,7 +331,7 @@ namespace Microsoft.AzureRepos.Tests
             authorityCacheMock.Setup(x => x.GetAuthority(OrgName)).Returns(authorityUrl);
 
             var userMgrMock = new Mock<IAzureReposBindingManager>(MockBehavior.Strict);
-            userMgrMock.Setup(x => x.GetBinding(OrgName)).Returns((AzureReposBinding)null);
+            userMgrMock.Setup(x => x.GetAccount(It.IsAny<AzureReposBindingScope>())).Returns((IMicrosoftAccount)null);
 
             var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCacheMock.Object, userMgrMock.Object);
 
@@ -326,7 +380,7 @@ namespace Microsoft.AzureRepos.Tests
             authorityCacheMock.Setup(x => x.GetAuthority(OrgName)).Returns(authorityUrl);
 
             var userMgrMock = new Mock<IAzureReposBindingManager>(MockBehavior.Strict);
-            userMgrMock.Setup(x => x.GetBinding(OrgName)).Returns((AzureReposBinding)null);
+            userMgrMock.Setup(x => x.GetAccount(It.IsAny<AzureReposBindingScope>())).Returns((IMicrosoftAccount)null);
 
             var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCacheMock.Object, userMgrMock.Object);
 
@@ -356,7 +410,7 @@ namespace Microsoft.AzureRepos.Tests
             var expectedRedirectUri = AzureDevOpsConstants.AadRedirectUri;
             var expectedScopes = AzureDevOpsConstants.AzureDevOpsDefaultScopes;
             var accessToken = "ACCESS-TOKEN";
-            var account = "john.doe";
+            var account = "john.doe@example.com";
             var expectedAccount = new MicrosoftAccount(homeAccountId: null, userName: account);
             var authResult = CreateAuthResult(account, accessToken);
 
@@ -371,13 +425,17 @@ namespace Microsoft.AzureRepos.Tests
             var msAuthMock = new Mock<IMicrosoftAuthentication>(MockBehavior.Strict);
             msAuthMock.Setup(x => x.GetTokenForUserAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, expectedAccount, true))
                       .ReturnsAsync(authResult);
+            msAuthMock.Setup(x => x.GetUserAccountsAsync(expectedClientId, true))
+                      .ReturnsAsync(System.Array.Empty<IMicrosoftAccount>());
 
             var authorityCacheMock = new Mock<IAzureDevOpsAuthorityCache>(MockBehavior.Strict);
             authorityCacheMock.Setup(x => x.GetAuthority(OrgName)).Returns(authorityUrl);
 
             var userMgrMock = new Mock<IAzureReposBindingManager>(MockBehavior.Strict);
-            userMgrMock.Setup(x => x.GetBinding(OrgName))
-                .Returns(new AzureReposBinding(OrgName, account, null));
+            userMgrMock.Setup(x => x.GetAccount(AzureReposBindingScope.ForOrg(OrgName, isLocal: false)))
+                .Returns(expectedAccount);
+            userMgrMock.Setup(x => x.GetAccount(AzureReposBindingScope.ForOrg(OrgName, isLocal: true)))
+                .Returns((IMicrosoftAccount)null);
 
             var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCacheMock.Object, userMgrMock.Object);
 
@@ -428,7 +486,7 @@ namespace Microsoft.AzureRepos.Tests
             authorityCacheMock.Setup(x => x.UpdateAuthority(OrgName, authorityUrl));
 
             var userMgrMock = new Mock<IAzureReposBindingManager>(MockBehavior.Strict);
-            userMgrMock.Setup(x => x.GetBinding(OrgName)).Returns((AzureReposBinding)null);
+            userMgrMock.Setup(x => x.GetAccount(It.IsAny<AzureReposBindingScope>())).Returns((IMicrosoftAccount)null);
 
             var provider = new AzureReposHostProvider(context, azDevOpsMock.Object, msAuthMock.Object, authorityCacheMock.Object, userMgrMock.Object);
 

--- a/src/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AzureRepos
 
         public const string UrnScheme = "azrepos";
         public const string UrnOrgPrefix = "org";
+        public const string UrnTenantPrefix = "tenant";
 
         public static class PersonalAccessTokenScopes
         {

--- a/src/Microsoft.AzureRepos/AzureReposBindingManager.cs
+++ b/src/Microsoft.AzureRepos/AzureReposBindingManager.cs
@@ -1,347 +1,287 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using GitCredentialManager;
+using GitCredentialManager.Authentication;
 
-namespace Microsoft.AzureRepos
+namespace Microsoft.AzureRepos;
+
+/// <summary>
+/// Manages bindings between Microsoft accounts and Azure DevOps tenants or organizations
+/// for the Azure Repos provider.
+/// </summary>
+/// <remarks>
+/// Bindings are pure preferences ("for this scope, prefer this account") and have no
+/// authentication state. They sit on top of the MSAL account cache (the source of truth
+/// for "which accounts do we have credentials for") and are resolved most-specific-first
+/// at credential time.
+/// </remarks>
+public interface IAzureReposBindingManager
 {
     /// <summary>
-    /// Manages bindings of users and organizations for Azure Repos.
+    /// Set the binding for the given scope to the given account.
     /// </summary>
-    public interface IAzureReposBindingManager
+    /// <param name="scope">Scope at which to bind.</param>
+    /// <param name="account">Account to bind. At least one of
+    /// <see cref="IMicrosoftAccount.HomeAccountId"/> or
+    /// <see cref="IMicrosoftAccount.UserName"/> must be populated; both is preferred so the
+    /// binding survives independently of the MSAL cache being able to resolve one to the
+    /// other.</param>
+    void Bind(AzureReposBindingScope scope, IMicrosoftAccount account);
+
+    /// <summary>
+    /// Remove the binding at the given scope, if any.
+    /// </summary>
+    void Unbind(AzureReposBindingScope scope);
+
+    /// <summary>
+    /// Read the account currently bound at the given scope, or <see langword="null"/> if none.
+    /// </summary>
+    /// <remarks>
+    /// The returned account carries whichever of <c>HomeAccountId</c> and <c>UserName</c> the
+    /// stored binding has on disk. New bindings always store both; legacy bindings written by
+    /// earlier releases stored only <c>UserName</c>.
+    /// </remarks>
+    IMicrosoftAccount GetAccount(AzureReposBindingScope scope);
+
+    /// <summary>
+    /// Enumerate every binding the manager knows about. Local-level entries are only enumerated
+    /// when inside a git repository.
+    /// </summary>
+    IEnumerable<AzureReposBinding> GetBindings();
+}
+
+/// <summary>
+/// A single stored binding: which scope it applies to and which account it points at.
+/// </summary>
+public sealed record AzureReposBinding(AzureReposBindingScope Scope, IMicrosoftAccount Account);
+
+public class AzureReposBindingManager : IAzureReposBindingManager
+{
+    private const string AccountIdProperty = "accountid";
+    private const string UserNameProperty = "username";
+
+    private readonly ITrace _trace;
+    private readonly IGit _git;
+
+    public AzureReposBindingManager(ICommandContext context) : this(context.Trace, context.Git) { }
+
+    public AzureReposBindingManager(ITrace trace, IGit git)
     {
-        /// <summary>
-        /// Get the binding for the given Azure DevOps organization.
-        /// </summary>
-        /// <param name="orgName">Organization name.</param>
-        /// <returns>Binding for the organization, or null if no binding exists.</returns>
-        AzureReposBinding GetBinding(string orgName);
+        EnsureArgument.NotNull(trace, nameof(trace));
+        EnsureArgument.NotNull(git, nameof(git));
 
-        /// <summary>
-        /// Bind a user to the given organization.
-        /// </summary>
-        /// <param name="orgName">Organization to bind the user to.</param>
-        /// <param name="userName">User identifier to bind.</param>
-        /// <param name="local">If true then bind local configuration, otherwise unbind global configuration.</param>
-        /// <remarks>
-        /// To prevent inheritance of a user binding at the global level, you can "bind" an organization
-        /// to a special <paramref name="userName"/> value <see cref="AzureReposBinding.NoInherit"/>.
-        /// <para/>
-        /// The special value <see cref="AzureReposBinding.NoInherit"/> can be used as the <paramref name="userName"/>
-        /// only when <paramref name="local"/> is true.
-        /// </remarks>
-        void Bind(string orgName, string userName, bool local);
-
-        /// <summary>
-        /// Unbind the given organization.
-        /// </summary>
-        /// <param name="orgName">Organization to unbind.</param>
-        /// <param name="local">If true then unbind local configuration, otherwise unbind global configuration.</param>
-        void Unbind(string orgName, bool local);
-
-        /// <summary>
-        /// Get all bindings to Azure DevOps organizations.
-        /// </summary>
-        /// <param name="orgName">Optional organization filter.</param>
-        /// <returns>All organization bindings.</returns>
-        IEnumerable<AzureReposBinding> GetBindings(string orgName = null);
+        _trace = trace;
+        _git = git;
     }
 
-    public class AzureReposBinding
+    public void Bind(AzureReposBindingScope scope, IMicrosoftAccount account)
     {
-        /// <summary>
-        /// Do not inherit any higher-level binding.
-        /// </summary>
-        public const string NoInherit = "";
-
-        public AzureReposBinding(string organization, string globalUserName, string localUserName)
+        EnsureArgument.NotNull(scope, nameof(scope));
+        EnsureArgument.NotNull(account, nameof(account));
+        if (string.IsNullOrWhiteSpace(account.HomeAccountId) &&
+            string.IsNullOrWhiteSpace(account.UserName))
         {
-            Organization = organization;
-            GlobalUserName = globalUserName;
-            LocalUserName = localUserName;
+            throw new ArgumentException(
+                "Account must have at least one of HomeAccountId or UserName populated.",
+                nameof(account));
         }
 
-        public string Organization { get; }
-        public string GlobalUserName { get; }
-        public string LocalUserName { get; }
+        GitConfigurationLevel level = GetConfigLevel(scope);
+        if (level == GitConfigurationLevel.Local && !_git.IsInsideRepository())
+        {
+            _trace.WriteLine("Cannot record local-scoped binding - not inside a repository.");
+            return;
+        }
+
+        string keyPrefix = GetKeyPrefix(scope);
+        _trace.WriteLine(
+            $"Recording binding for scope '{keyPrefix}' at {level} " +
+            $"(accountid='{account.HomeAccountId}', username='{account.UserName}').");
+
+        IGitConfiguration config = _git.GetConfiguration();
+        WriteOrClear(config, level, $"{keyPrefix}.{AccountIdProperty}", account.HomeAccountId);
+        WriteOrClear(config, level, $"{keyPrefix}.{UserNameProperty}", account.UserName);
     }
 
-    public class AzureReposBindingManager : IAzureReposBindingManager
+    public void Unbind(AzureReposBindingScope scope)
     {
-        private readonly ITrace _trace;
-        private readonly IGit _git;
+        EnsureArgument.NotNull(scope, nameof(scope));
 
-        public AzureReposBindingManager(ICommandContext context) : this(context.Trace, context.Git) { }
-
-        public AzureReposBindingManager(ITrace trace, IGit git)
+        GitConfigurationLevel level = GetConfigLevel(scope);
+        if (level == GitConfigurationLevel.Local && !_git.IsInsideRepository())
         {
-            EnsureArgument.NotNull(trace, nameof(trace));
-            EnsureArgument.NotNull(git, nameof(git));
-
-            _trace = trace;
-            _git = git;
+            _trace.WriteLine("Cannot remove local-scoped binding - not inside a repository.");
+            return;
         }
 
-        public AzureReposBinding GetBinding(string orgName)
+        string keyPrefix = GetKeyPrefix(scope);
+        _trace.WriteLine($"Removing binding for scope '{keyPrefix}' at {level}.");
+
+        IGitConfiguration config = _git.GetConfiguration();
+        config.Unset(level, $"{keyPrefix}.{AccountIdProperty}");
+        config.Unset(level, $"{keyPrefix}.{UserNameProperty}");
+    }
+
+    public IMicrosoftAccount GetAccount(AzureReposBindingScope scope)
+    {
+        EnsureArgument.NotNull(scope, nameof(scope));
+
+        GitConfigurationLevel level = GetConfigLevel(scope);
+        if (level == GitConfigurationLevel.Local && !_git.IsInsideRepository())
         {
-            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
-
-            string orgKey = GetOrgUserKey(orgName);
-
-            IGitConfiguration config = _git.GetConfiguration();
-
-            _trace.WriteLine($"Looking up organization binding for '{orgName}'...");
-
-            string localUser = null;
-            bool hasLocal = _git.IsInsideRepository() && // Can only check local config if we are inside a repository
-                            config.TryGet(GitConfigurationLevel.Local, GitConfigurationType.Raw,
-                                orgKey, out localUser);
-
-            bool hasGlobal = config.TryGet(GitConfigurationLevel.Global, GitConfigurationType.Raw,
-                orgKey, out string globalUser);
-
-            if (hasLocal || hasGlobal)
-            {
-                return new AzureReposBinding(orgName, globalUser, localUser);
-            }
-
-            // No bound user
             return null;
         }
 
-        public void Bind(string orgName, string userName, bool local)
+        string keyPrefix = GetKeyPrefix(scope);
+        IGitConfiguration config = _git.GetConfiguration();
+
+        string accountId = TryGet(config, level, $"{keyPrefix}.{AccountIdProperty}");
+        string userName  = TryGet(config, level, $"{keyPrefix}.{UserNameProperty}");
+
+        if (accountId is null && userName is null) return null;
+        return new MicrosoftAccount(accountId, userName);
+    }
+
+    public IEnumerable<AzureReposBinding> GetBindings()
+    {
+        IGitConfiguration config = _git.GetConfiguration();
+
+        foreach (AzureReposBinding b in EnumerateBindings(config, GitConfigurationLevel.Global, isLocal: false))
+            yield return b;
+
+        if (_git.IsInsideRepository())
         {
-            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
-
-            IGitConfiguration config = _git.GetConfiguration();
-
-            string key = GetOrgUserKey(orgName);
-
-            if (local)
-            {
-                _trace.WriteLine(userName == AzureReposBinding.NoInherit
-                    ? $"Setting binding to 'do not inherit' for organization '{orgName}' in local repository..."
-                    : $"Binding user '{userName}' to organization '{orgName}' in local repository...");
-
-                if (_git.IsInsideRepository())
-                {
-                    config.Set(GitConfigurationLevel.Local, key, userName);
-                }
-                else
-                {
-                    _trace.WriteLine("Cannot set local configuration binding - not inside a repository!");
-                }
-            }
-            else
-            {
-                EnsureArgument.NotNullOrWhiteSpace(userName, nameof(userName));
-
-                _trace.WriteLine($"Binding user '{userName}' to organization '{orgName}' in global configuration...");
-                config.Set(GitConfigurationLevel.Global, key, userName);
-            }
-        }
-
-        public void Unbind(string orgName, bool local)
-        {
-            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
-
-            IGitConfiguration config = _git.GetConfiguration();
-
-            string key = GetOrgUserKey(orgName);
-
-            if (local)
-            {
-                _trace.WriteLine($"Unbinding organization '{orgName}' in local repository...");
-                if (_git.IsInsideRepository())
-                {
-                    config.Unset(GitConfigurationLevel.Local, key);
-                }
-                else
-                {
-                    _trace.WriteLine("Cannot set local configuration binding - not inside a repository!");
-                }
-            }
-            else
-            {
-                _trace.WriteLine($"Unbinding organization '{orgName}' in global configuration...");
-                config.Unset(GitConfigurationLevel.Global, key);
-            }
-        }
-
-        public IEnumerable<AzureReposBinding> GetBindings(string orgName = null)
-        {
-            var globalUsers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            var localUsers  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-            IGitConfiguration config = _git.GetConfiguration();
-
-            string orgPrefix = $"{AzureDevOpsConstants.UrnOrgPrefix}/";
-
-            bool ExtractUserBinding(GitConfigurationEntry entry, IDictionary<string, string> dict)
-            {
-                if (GitConfigurationKeyComparer.TrySplit(entry.Key, out _, out string scope, out _) &&
-                    Uri.TryCreate(scope, UriKind.Absolute, out Uri uri) &&
-                    uri.Scheme == AzureDevOpsConstants.UrnScheme && uri.AbsolutePath.StartsWith(orgPrefix))
-                {
-                    string entryOrgName = uri.AbsolutePath.Substring(orgPrefix.Length);
-                    if (string.IsNullOrWhiteSpace(orgName) || StringComparer.OrdinalIgnoreCase.Equals(entryOrgName, orgName))
-                    {
-                        dict[entryOrgName] = entry.Value;
-                    }
-                }
-
-                return true;
-            }
-
-            // Only enumerate local configuration if we are inside a repository
-            if (_git.IsInsideRepository())
-            {
-                config.Enumerate(
-                    GitConfigurationLevel.Local,
-                    Constants.GitConfiguration.Credential.SectionName,
-                    Constants.GitConfiguration.Credential.UserName,
-                    entry => ExtractUserBinding(entry, localUsers));
-            }
-
-            config.Enumerate(
-                GitConfigurationLevel.Global,
-                Constants.GitConfiguration.Credential.SectionName,
-                Constants.GitConfiguration.Credential.UserName,
-                entry => ExtractUserBinding(entry, globalUsers));
-
-            foreach (string org in globalUsers.Keys.Union(localUsers.Keys))
-            {
-                // NOT using the short-circuiting OR operator here on purpose - we need both branches to be evaluated
-                if (globalUsers.TryGetValue(org, out string globalUser) | localUsers.TryGetValue(org, out string localUser))
-                {
-                    yield return new AzureReposBinding(org, globalUser, localUser);
-                }
-            }
-        }
-
-        private static string GetOrgUserKey(string orgName)
-        {
-            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}:{2}/{3}.{4}",
-                Constants.GitConfiguration.Credential.SectionName,
-                AzureDevOpsConstants.UrnScheme, AzureDevOpsConstants.UrnOrgPrefix, orgName,
-                "username"
-            );
+            foreach (AzureReposBinding b in EnumerateBindings(config, GitConfigurationLevel.Local, isLocal: true))
+                yield return b;
         }
     }
 
-    public static class AzureReposUserManagerExtensions
+    private static IEnumerable<AzureReposBinding> EnumerateBindings(
+        IGitConfiguration config, GitConfigurationLevel level, bool isLocal)
     {
-        /// <summary>
-        /// Get the user that is bound to the specified Azure DevOps organization.
-        /// </summary>
-        /// <param name="bindingManager">Binding manager.</param>
-        /// <param name="orgName">Organization name.</param>
-        /// <returns>User identifier bound to the organization, or null if no such bound user exists.</returns>
-        public static string GetUser(this IAzureReposBindingManager bindingManager, string orgName)
-        {
-            AzureReposBinding binding = bindingManager.GetBinding(orgName);
-            if (binding is null || binding.LocalUserName == AzureReposBinding.NoInherit)
-            {
-                return null;
-            }
+        var accountIds = new Dictionary<AzureReposBindingScope, string>();
+        var userNames  = new Dictionary<AzureReposBindingScope, string>();
 
-            return binding.LocalUserName ?? binding.GlobalUserName;
+        config.Enumerate(level, Constants.GitConfiguration.Credential.SectionName,
+            AccountIdProperty, entry =>
+        {
+            AzureReposBindingScope scope = ParseScopeFromKey(entry.Key, isLocal);
+            if (scope is not null) accountIds[scope] = entry.Value;
+            return true;
+        });
+
+        config.Enumerate(level, Constants.GitConfiguration.Credential.SectionName,
+            UserNameProperty, entry =>
+        {
+            AzureReposBindingScope scope = ParseScopeFromKey(entry.Key, isLocal);
+            if (scope is not null) userNames[scope] = entry.Value;
+            return true;
+        });
+
+        var scopes = new HashSet<AzureReposBindingScope>(accountIds.Keys);
+        scopes.UnionWith(userNames.Keys);
+
+        var bindings = new List<AzureReposBinding>(scopes.Count);
+        foreach (AzureReposBindingScope scope in scopes)
+        {
+            accountIds.TryGetValue(scope, out string accountId);
+            userNames.TryGetValue(scope, out string userName);
+            bindings.Add(new AzureReposBinding(scope, new MicrosoftAccount(accountId, userName)));
+        }
+        return bindings;
+    }
+
+    private static AzureReposBindingScope ParseScopeFromKey(string key, bool isLocal)
+    {
+        if (!GitConfigurationKeyComparer.TrySplit(key, out _, out string subsection, out _))
+            return null;
+
+        if (!Uri.TryCreate(subsection, UriKind.Absolute, out Uri uri))
+            return null;
+        if (!StringComparer.OrdinalIgnoreCase.Equals(uri.Scheme, AzureDevOpsConstants.UrnScheme))
+            return null;
+
+        string path = uri.AbsolutePath;
+        if (path.StartsWith(AzureDevOpsConstants.UrnOrgPrefix + "/", StringComparison.OrdinalIgnoreCase))
+        {
+            return AzureReposBindingScope.ForOrg(path.Substring(AzureDevOpsConstants.UrnOrgPrefix.Length + 1), isLocal);
+        }
+        if (path.StartsWith(AzureDevOpsConstants.UrnTenantPrefix + "/", StringComparison.OrdinalIgnoreCase))
+        {
+            return AzureReposBindingScope.ForTenant(path.Substring(AzureDevOpsConstants.UrnTenantPrefix.Length + 1), isLocal);
+        }
+        return null;
+    }
+
+    private static GitConfigurationLevel GetConfigLevel(AzureReposBindingScope scope) =>
+        scope.IsLocal ? GitConfigurationLevel.Local : GitConfigurationLevel.Global;
+
+    private static string GetKeyPrefix(AzureReposBindingScope scope)
+    {
+        (string k, string v) = scope switch
+        {
+            AzureReposBindingScope.Tenant t => (AzureDevOpsConstants.UrnTenantPrefix, t.TenantId),
+            AzureReposBindingScope.Org o    => (AzureDevOpsConstants.UrnOrgPrefix, o.OrgName),
+            _ => throw new ArgumentException("Unknown scope", nameof(scope))
+        };
+
+        return string.Format(
+            CultureInfo.InvariantCulture, "{0}.{1}:{2}/{3}",
+            Constants.GitConfiguration.Credential.SectionName,
+            AzureDevOpsConstants.UrnScheme, k, v
+        );
+    }
+
+    private static void WriteOrClear(IGitConfiguration config, GitConfigurationLevel level, string key, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            config.Unset(level, key);
+        else
+            config.Set(level, key, value);
+    }
+
+    private static string TryGet(IGitConfiguration config, GitConfigurationLevel level, string key) =>
+        config.TryGet(level, GitConfigurationType.Raw, key, out string value) ? value : null;
+}
+
+public static class AzureReposBindingManagerExtensions
+{
+    /// <summary>
+    /// Resolve the account to use for a credential request against the given Azure DevOps
+    /// organization and/or Microsoft Entra tenant.
+    /// </summary>
+    /// <remarks>
+    /// Precedence (most specific to least): Org local, Org global, Tenant local, Tenant global.
+    /// Tenant lookup is skipped when <paramref name="tenantId"/> is <see langword="null"/>
+    /// (caller couldn't resolve the org's tenant).
+    /// </remarks>
+    public static IMicrosoftAccount ResolveAccountBinding(this IAzureReposBindingManager manager, string orgName, string tenantId)
+    {
+        EnsureArgument.NotNull(manager, nameof(manager));
+        EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
+
+        // Local binding for an org
+        IMicrosoftAccount account = manager.GetAccount(AzureReposBindingScope.ForOrg(orgName, isLocal: true));
+        if (account is not null) return account;
+
+        // Global binding for an org
+        account = manager.GetAccount(AzureReposBindingScope.ForOrg(orgName, isLocal: false));
+        if (account is not null) return account;
+
+        // Look for a less scoped tenant-binding
+        if (!string.IsNullOrWhiteSpace(tenantId))
+        {
+            // Local binding for a tenant
+            account = manager.GetAccount(AzureReposBindingScope.ForTenant(tenantId, isLocal: true));
+            if (account is not null) return account;
+
+            // Global binding for a tenant
+            account = manager.GetAccount(AzureReposBindingScope.ForTenant(tenantId, isLocal: false));
+            if (account is not null) return account;
         }
 
-        /// <summary>
-        /// Marks a user as 'signed in' to an Azure DevOps organization.
-        /// </summary>
-        /// <param name="bindingManager">Binding manager.</param>
-        /// <param name="orgName">Organization name.</param>
-        /// <param name="userName">User identifier to bind to this organization.</param>
-        public static void SignIn(this IAzureReposBindingManager bindingManager, string orgName, string userName)
-        {
-            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
-            EnsureArgument.NotNullOrWhiteSpace(userName, nameof(userName));
-
-            //
-            // Try to bind the user to the organization.
-            //
-            //   A = User to sign-in
-            //   B = Another user
-            //   - = No user
-            //
-            //  Global | Local | -> | Global | Local
-            // --------|-------|----|--------|-------
-            //    -    |   -   | -> |   A    |   -
-            //    -    |   A   | -> |   A    |   -
-            //    -    |   B   | -> |   A    |   -
-            //    A    |   -   | -> |   A    |   -
-            //    A    |   A   | -> |   A    |   -
-            //    A    |   B   | -> |   A    |   -
-            //    B    |   -   | -> |   B    |   A
-            //    B    |   A   | -> |   B    |   A
-            //    B    |   B   | -> |   B    |   A
-            //
-            AzureReposBinding existingBinding = bindingManager.GetBinding(orgName);
-            if (existingBinding?.GlobalUserName != null &&
-                !StringComparer.OrdinalIgnoreCase.Equals(existingBinding.GlobalUserName, userName))
-            {
-                // Global is bound to a different user (B); bind this user locally (-> B | A).
-                // Skip the write if local is already correct.
-                if (!StringComparer.OrdinalIgnoreCase.Equals(existingBinding.LocalUserName, userName))
-                {
-                    bindingManager.Bind(orgName, userName, local: true);
-                }
-            }
-            else
-            {
-                // Global is absent or already matches; ensure global is set and local is clear.
-                if (existingBinding?.GlobalUserName is null)
-                {
-                    bindingManager.Bind(orgName, userName, local: false);
-                }
-                if (existingBinding?.LocalUserName is not null)
-                {
-                    bindingManager.Unbind(orgName, local: true);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Marks a user as 'signed out' of an Azure DevOps organization.
-        /// </summary>
-        /// <param name="bindingManager">Binding manager.</param>
-        /// <param name="orgName">Organization name.</param>
-        public static void SignOut(this IAzureReposBindingManager bindingManager, string orgName)
-        {
-            EnsureArgument.NotNullOrWhiteSpace(orgName, nameof(orgName));
-
-            //
-            // Unbind the organization so we prompt the user to select a user on the next attempt.
-            //
-            //   U = User
-            //   X = Do not inherit (valid in local only)
-            //   - = No user
-            //
-            //  Global | Local | -> | Global | Local
-            // --------|-------|----|--------|-------
-            //    -    |   -   | -> |   -    |   -
-            //    -    |   U   | -> |   -    |   -
-            //    -    |   X   | -> |   -    |   -
-            //    U    |   -   | -> |   U    |   X
-            //    U    |   X   | -> |   U    |   X
-            //    U    |   U   | -> |   U    |   X
-            //
-            AzureReposBinding existingBinding = bindingManager.GetBinding(orgName);
-            if (existingBinding is null)
-            {
-                // Nothing to do!
-            }
-            else if (existingBinding.GlobalUserName is null)
-            {
-                bindingManager.Unbind(orgName, local: true);
-            }
-            else
-            {
-                bindingManager.Bind(orgName, AzureReposBinding.NoInherit, local: true);
-            }
-        }
+        // No binding available!
+        return null;
     }
 }

--- a/src/Microsoft.AzureRepos/AzureReposBindingScope.cs
+++ b/src/Microsoft.AzureRepos/AzureReposBindingScope.cs
@@ -1,0 +1,44 @@
+namespace Microsoft.AzureRepos;
+
+/// <summary>
+/// Identifies a binding for the Azure Repos provider: what the binding applies to
+/// (a tenant or an Azure DevOps organization) and whether it lives at the global or local
+/// (per-clone) git-config level.
+/// </summary>
+/// <remarks>
+/// Modelled as a sealed discriminated union so callers can pattern-match exhaustively at
+/// compile time. The <c>IsLocal</c> flag carried by each case is what distinguishes a
+/// per-clone override from a machine-wide preference; the same identity can exist at both
+/// levels simultaneously, with local taking precedence on resolution.
+/// </remarks>
+public abstract record AzureReposBindingScope
+{
+    private AzureReposBindingScope() { }
+
+    public static AzureReposBindingScope ForTenant(string tenantId, bool isLocal = false) =>
+        new Tenant(tenantId, isLocal);
+    public static AzureReposBindingScope ForOrg(string orgName, bool isLocal = false) =>
+        new Org(orgName, isLocal);
+
+    /// <summary>
+    /// True if this scope lives at the per-clone (local) git-config level rather than the
+    /// machine-wide (global) level.
+    /// </summary>
+    public abstract bool IsLocal { get; }
+
+    /// <summary>
+    /// "Use this account for any Azure DevOps organization backed by the given Microsoft Entra tenant."
+    /// </summary>
+    public sealed record Tenant(string TenantId, bool IsLocal = false) : AzureReposBindingScope
+    {
+        public override bool IsLocal { get; } = IsLocal;
+    }
+
+    /// <summary>
+    /// "Use this account for this specific Azure DevOps organization, regardless of which tenant it lives in."
+    /// </summary>
+    public sealed record Org(string OrgName, bool IsLocal = false) : AzureReposBindingScope
+    {
+        public override bool IsLocal { get; } = IsLocal;
+    }
+}

--- a/src/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -829,9 +829,36 @@ namespace Microsoft.AzureRepos
             clearCacheCmd.SetHandler(ClearCacheCmd);
 
             //
-            // list <organization> [--show-remotes] [--verbose]
+            // login [--tenant <id|domain>]
             //
-            var listCmd = new Command("list", "List all user account bindings");
+            var loginCmd = new Command("login", "Sign in to a Microsoft account and add it to the credential cache");
+            var loginTenantOpt = new Option<string>("--tenant", "Sign in to a specific Microsoft Entra tenant (GUID or domain). Required when adding a guest account whose home tenant is different from the tenant you want to use it for.");
+            loginCmd.AddOption(loginTenantOpt);
+            loginCmd.SetHandler(LoginCmd, loginTenantOpt);
+
+            //
+            // logout (<account> | --all)
+            //
+            var logoutCmd = new Command("logout", "Remove a Microsoft account from the credential cache");
+            var logoutAccountArg = new Argument<string>("account", "Account to remove (UPN or HomeAccountId)")
+            {
+                Arity = ArgumentArity.ZeroOrOne
+            };
+            var logoutAllOpt = new Option<bool>("--all", "Remove every cached Microsoft account");
+            logoutCmd.AddArgument(logoutAccountArg);
+            logoutCmd.AddOption(logoutAllOpt);
+            logoutCmd.SetHandler(LogoutCmd, logoutAccountArg, logoutAllOpt);
+
+            //
+            // list
+            //
+            var listCmd = new Command("list", "List Microsoft accounts in the credential cache");
+            listCmd.SetHandler(ListCmd);
+
+            //
+            // list-bindings [<organization>] [--show-remotes] [--verbose]
+            //
+            var listBindingsCmd = new Command("list-bindings", "List all user account bindings");
             var orgFilterArg = new Argument<string>("organization", "(optional) Filter results by Azure DevOps organization name")
             {
                 Arity = ArgumentArity.ZeroOrOne
@@ -841,10 +868,10 @@ namespace Microsoft.AzureRepos
                 Description = "Also show Azure DevOps remote user bindings for the current repository"
             };
             var verboseOpt = new Option<bool>(new[] { "--verbose", "-v" }, "Verbose output - show remote URLs");
-            listCmd.AddArgument(orgFilterArg);
-            listCmd.AddOption(remoteOpt);
-            listCmd.AddOption(verboseOpt);
-            listCmd.SetHandler(ListCmd, orgFilterArg, remoteOpt, verboseOpt);
+            listBindingsCmd.AddArgument(orgFilterArg);
+            listBindingsCmd.AddOption(remoteOpt);
+            listBindingsCmd.AddOption(verboseOpt);
+            listBindingsCmd.SetHandler(ListBindingsCmd, orgFilterArg, remoteOpt, verboseOpt);
 
             //
             // bind <organization> <username> [--local]
@@ -876,7 +903,10 @@ namespace Microsoft.AzureRepos
             unbindCmd.SetHandler(UnbindCmd, orgArg, localOpt);
 
             var rootCmd = new ProviderCommand(this);
+            rootCmd.AddCommand(loginCmd);
+            rootCmd.AddCommand(logoutCmd);
             rootCmd.AddCommand(listCmd);
+            rootCmd.AddCommand(listBindingsCmd);
             rootCmd.AddCommand(bindCmd);
             rootCmd.AddCommand(unbindCmd);
             rootCmd.AddCommand(clearCacheCmd);
@@ -889,6 +919,125 @@ namespace Microsoft.AzureRepos
             _context.Console.WriteLine("Authority cache cleared");
         }
 
+        private async Task<int> LoginCmd(string tenantId)
+        {
+            // Pick the authority MSAL signs in against. By default we use the wildcard
+            // `organizations` authority so the user can pick any work/school account; an
+            // explicit --tenant constrains to one tenant (the only way to pre-stage a
+            // guest-account record for a non-home tenant).
+            string authority = !string.IsNullOrWhiteSpace(tenantId)
+                ? $"{AzureDevOpsConstants.AadAuthorityBaseUrl}/{tenantId}"
+                : $"{AzureDevOpsConstants.AadAuthorityBaseUrl}/organizations";
+
+            IMicrosoftAuthenticationResult result;
+            try
+            {
+                result = await _msAuth.GetTokenForUserAsync(
+                    authority,
+                    GetClientId(),
+                    GetRedirectUri(),
+                    AzureDevOpsConstants.AzureDevOpsDefaultScopes,
+                    account: null,
+                    msaPt: true);
+            }
+            catch (Exception ex)
+            {
+                _context.Streams.Error.WriteLine($"error: sign-in failed: {ex.Message}");
+                return -1;
+            }
+
+            if (result.Account is null || string.IsNullOrWhiteSpace(result.Account.HomeAccountId))
+            {
+                _context.Streams.Error.WriteLine(
+                    "error: sign-in succeeded but no account identifier was returned");
+                return -1;
+            }
+
+            _context.Streams.Out.WriteLine($"Signed in as {result.Account.UserName}.");
+            return 0;
+        }
+
+        private async Task<int> LogoutCmd(string account, bool all)
+        {
+            bool hasAccount = !string.IsNullOrWhiteSpace(account);
+            if (all == hasAccount)
+            {
+                _context.Streams.Error.WriteLine("error: specify either <account> or --all");
+                return -1;
+            }
+
+            IReadOnlyList<IMicrosoftAccount> cached =
+                await _msAuth.GetUserAccountsAsync(GetClientId(), msaPt: true);
+
+            if (cached.Count == 0)
+            {
+                _context.Streams.Out.WriteLine("No accounts cached.");
+                return 0;
+            }
+
+            IEnumerable<IMicrosoftAccount> targets;
+            if (all)
+            {
+                targets = cached;
+            }
+            else
+            {
+                IMicrosoftAccount[] matches = cached.Where(a =>
+                        StringComparer.OrdinalIgnoreCase.Equals(a.UserName, account) ||
+                        StringComparer.Ordinal.Equals(a.HomeAccountId, account))
+                    .ToArray();
+                if (matches.Length == 0)
+                {
+                    _context.Streams.Error.WriteLine($"error: no cached account matches '{account}'");
+                    return -1;
+                }
+                if (matches.Length > 1)
+                {
+                    _context.Streams.Error.WriteLine(
+                        $"error: '{account}' is ambiguous; specify the HomeAccountId of the account to remove:");
+                    foreach (IMicrosoftAccount m in matches)
+                    {
+                        _context.Streams.Error.WriteLine($"  {m.UserName}  ({m.HomeAccountId})");
+                    }
+                    return -1;
+                }
+                targets = matches;
+            }
+
+            int removed = 0;
+            foreach (IMicrosoftAccount target in targets)
+            {
+                if (await _msAuth.RemoveUserAccountAsync(GetClientId(), target, msaPt: true))
+                {
+                    _context.Streams.Out.WriteLine($"Signed out {target.UserName}.");
+                    removed++;
+                }
+            }
+
+            return removed > 0 ? 0 : -1;
+        }
+
+        private async Task<int> ListCmd()
+        {
+            IReadOnlyList<IMicrosoftAccount> cached =
+                await _msAuth.GetUserAccountsAsync(GetClientId(), msaPt: true);
+
+            if (cached.Count == 0)
+            {
+                _context.Streams.Out.WriteLine("No accounts cached.");
+                return 0;
+            }
+
+            foreach (IMicrosoftAccount account in cached
+                         .OrderBy(a => a.UserName ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+            {
+                _context.Streams.Out.WriteLine(account.UserName ?? "(unknown)");
+                _context.Streams.Out.WriteLine($"  {account.HomeAccountId}");
+            }
+
+            return 0;
+        }
+
         private class RemoteBinding
         {
             public string Remote { get; set; }
@@ -896,7 +1045,7 @@ namespace Microsoft.AzureRepos
             public Uri Uri { get; set; }
         }
 
-        private void ListCmd(string organization, bool showRemotes, bool verbose)
+        private void ListBindingsCmd(string organization, bool showRemotes, bool verbose)
         {
             // Get all organization bindings from the user manager
             IList<AzureReposBinding> bindings = _bindingManager.GetBindings(organization).ToList();

--- a/src/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -345,12 +345,15 @@ namespace Microsoft.AzureRepos
 
             // Get an AAD access token for the Azure DevOps SPS
             _context.Trace.WriteLine("Getting Azure AD access token...");
+            IMicrosoftAccount account = string.IsNullOrWhiteSpace(userName)
+                ? null
+                : new MicrosoftAccount(homeAccountId: null, userName: userName);
             IMicrosoftAuthenticationResult result = await _msAuth.GetTokenForUserAsync(
                 authAuthority,
                 GetClientId(),
                 GetRedirectUri(),
                 AzureDevOpsConstants.AzureDevOpsDefaultScopes,
-                userName,
+                account,
                 msaPt: true);
             _context.Trace.WriteLineSecrets(
                 $"Acquired Azure access token. Account='{result.Account.UserName}' Token='{{0}}'", new object[] {result.AccessToken});

--- a/src/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -139,7 +139,7 @@ namespace Microsoft.AzureRepos
             }
         }
 
-        public Task StoreCredentialAsync(GitRequest request)
+        public async Task StoreCredentialAsync(GitRequest request)
         {
             Uri remoteUri = request.GetRemoteUri();
 
@@ -171,11 +171,20 @@ namespace Microsoft.AzureRepos
             else
             {
                 string orgName = UriHelpers.GetOrganizationName(remoteUri);
-                _context.Trace.WriteLine($"Signing user {request.UserName} in to organization '{orgName}'...");
-                _bindingManager.SignIn(orgName, request.UserName);
-            }
+                _context.Trace.WriteLine($"Recording binding for user {request.UserName} -> organization '{orgName}'...");
 
-            return Task.CompletedTask;
+                // The incoming user name can be either a UPN or a HomeAccountId — match the cache
+                // by either field, then fall back to a `MicrosoftAccount.FromIdentifier`-classified
+                // binding when the cache has nothing to say. The binding manager always writes both
+                // fields it knows.
+                IReadOnlyList<IMicrosoftAccount> cached =
+                    await _msAuth.GetUserAccountsAsync(GetClientId(), msaPt: true);
+                IMicrosoftAccount match = cached.FirstOrDefault(a =>
+                    StringComparer.OrdinalIgnoreCase.Equals(a.UserName, request.UserName) ||
+                    StringComparer.Ordinal.Equals(a.HomeAccountId, request.UserName));
+                IMicrosoftAccount toBind = match ?? MicrosoftAccount.FromIdentifier(request.UserName);
+                _bindingManager.Bind(AzureReposBindingScope.ForOrg(orgName), toBind);
+            }
         }
 
         public Task EraseCredentialAsync(GitRequest request)
@@ -215,8 +224,19 @@ namespace Microsoft.AzureRepos
             {
                 string orgName = UriHelpers.GetOrganizationName(remoteUri);
 
-                _context.Trace.WriteLine($"Signing out of organization '{orgName}'...");
-                _bindingManager.SignOut(orgName);
+                _context.Trace.WriteLine($"Clearing binding for organization '{orgName}'...");
+
+                // Remove the most specific binding first; a global binding remains if a local one
+                // covered it and only the local one was the cause of the credential failure.
+                var localOrg = AzureReposBindingScope.ForOrg(orgName, isLocal: true);
+                if (_bindingManager.GetAccount(localOrg) != null)
+                {
+                    _bindingManager.Unbind(localOrg);
+                }
+                else
+                {
+                    _bindingManager.Unbind(AzureReposBindingScope.ForOrg(orgName, isLocal: false));
+                }
 
                 // Clear the authority cache in case this was the reason for failure
                 _authorityCache.EraseAuthority(orgName);
@@ -325,29 +345,37 @@ namespace Microsoft.AzureRepos
             // match the Azure DevOps organization name. Our friends in Azure DevOps decided "borrow" the username
             // part of the remote URL to include the organization name (not an actual username).
             //
-            // If we have no specified user from the remote (or this is org@dev.azure.com/org/..) then query the
-            // user manager for a bound user for this organization, if one exists...
+            // The user-info string can be either a UPN or a HomeAccountId —
+            // `MicrosoftAccount.FromIdentifier` decides which field of the `IMicrosoftAccount`
+            // to populate so msauth's HomeAccountId-first / UPN-fallback resolution sees it in
+            // the right slot.
             //
+            // If we have no specified user from the remote (or this is org@dev.azure.com/org/..) then query the
+            // binding manager for the account to use for this organization, if one is bound. The tenant id
+            // (derived from the authority URL) lets us also consider tenant-scoped bindings.
+            //
+            IMicrosoftAccount account = null;
             var icmp = StringComparer.OrdinalIgnoreCase;
             if (!string.IsNullOrWhiteSpace(userName) &&
                 (UriHelpers.IsVisualStudioComHost(remoteWithUserUri.Host) ||
                  (UriHelpers.IsAzureDevOpsHost(remoteWithUserUri.Host) && !icmp.Equals(orgName, userName))))
             {
                 _context.Trace.WriteLine("Using username as specified in remote.");
+                account = MicrosoftAccount.FromIdentifier(userName);
             }
             else
             {
-                _context.Trace.WriteLine($"Looking up user for organization '{orgName}'...");
-                userName = _bindingManager.GetUser(orgName);
+                _context.Trace.WriteLine($"Resolving account for organization '{orgName}'...");
+                string tenantId = TryExtractTenantIdFromAuthority(authAuthority);
+                account = _bindingManager.ResolveAccountBinding(orgName, tenantId);
             }
 
-            _context.Trace.WriteLine(string.IsNullOrWhiteSpace(userName) ? "No user found." : $"User is '{userName}'.");
+            _context.Trace.WriteLine(account is null
+                ? "No bound account; msauth will pick interactively."
+                : $"Using account '{account.UserName ?? account.HomeAccountId}'.");
 
             // Get an AAD access token for the Azure DevOps SPS
             _context.Trace.WriteLine("Getting Azure AD access token...");
-            IMicrosoftAccount account = string.IsNullOrWhiteSpace(userName)
-                ? null
-                : new MicrosoftAccount(homeAccountId: null, userName: userName);
             IMicrosoftAuthenticationResult result = await _msAuth.GetTokenForUserAsync(
                 authAuthority,
                 GetClientId(),
@@ -359,6 +387,28 @@ namespace Microsoft.AzureRepos
                 $"Acquired Azure access token. Account='{result.Account.UserName}' Token='{{0}}'", new object[] {result.AccessToken});
 
             return result;
+        }
+
+        /// <summary>
+        /// Extract the tenant id from a Microsoft authentication authority URL of the form
+        /// <c>https://login.microsoftonline.com/{tenant}[/...]</c>. Returns <see langword="null"/>
+        /// for malformed or unrecognized authorities (including the wildcard <c>common</c> and
+        /// <c>organizations</c> values, which don't identify a specific tenant).
+        /// </summary>
+        private static string TryExtractTenantIdFromAuthority(string authority)
+        {
+            if (string.IsNullOrWhiteSpace(authority)) return null;
+            if (!Uri.TryCreate(authority, UriKind.Absolute, out Uri uri)) return null;
+
+            string first = uri.AbsolutePath.Trim('/').Split('/')[0];
+            if (string.IsNullOrEmpty(first)) return null;
+            if (StringComparer.OrdinalIgnoreCase.Equals(first, "common") ||
+                StringComparer.OrdinalIgnoreCase.Equals(first, "organizations") ||
+                StringComparer.OrdinalIgnoreCase.Equals(first, "consumers"))
+            {
+                return null;
+            }
+            return first;
         }
 
         internal /* for testing purposes */ static bool TryGetAuthorityFromHeaders(IEnumerable<string> headers, out string authority)
@@ -874,33 +924,32 @@ namespace Microsoft.AzureRepos
             listBindingsCmd.SetHandler(ListBindingsCmd, orgFilterArg, remoteOpt, verboseOpt);
 
             //
-            // bind <organization> <username> [--local]
+            // bind <account> [--tenant <id> | --org <name>] [--local]
             //
-            var bindCmd = new Command("bind", "Bind a user account to an Azure DevOps organization");
-            var orgArg = new Argument<string>("organization", "Azure DevOps organization name")
+            var bindCmd = new Command("bind", "Bind a Microsoft account to a tenant or Azure DevOps organization");
+            var bindAccountArg = new Argument<string>("account", "Account to bind (UPN or HomeAccountId of an account from `azure-repos list`)")
             {
                 Arity = ArgumentArity.ExactlyOne
             };
-            var userNameArg = new Argument<string>("username", "Username or email (e.g.: alice@example.com)")
-            {
-                Arity = ArgumentArity.ExactlyOne
-            };
+            var bindTenantOpt = new Option<string>("--tenant", "Bind for any organization backed by the given Microsoft Entra tenant");
+            var bindOrgOpt = new Option<string>("--org", "Bind for the given Azure DevOps organization");
             var localOpt = new Option<bool>("--local", "Target the local repository Git configuration");
-            bindCmd.AddArgument(orgArg);
-            bindCmd.AddArgument(userNameArg);
+            bindCmd.AddArgument(bindAccountArg);
+            bindCmd.AddOption(bindTenantOpt);
+            bindCmd.AddOption(bindOrgOpt);
             bindCmd.AddOption(localOpt);
-            bindCmd.SetHandler(BindCmd, orgArg, userNameArg, localOpt);
+            bindCmd.SetHandler(BindCmd, bindAccountArg, bindTenantOpt, bindOrgOpt, localOpt);
 
             //
-            // unbind <organization> [--local]
+            // unbind [--tenant <id> | --org <name>] [--local]
             //
-            var unbindCmd = new Command("unbind")
-            {
-                Description = "Remove user account binding for an Azure DevOps organization",
-            };
-            unbindCmd.AddArgument(orgArg);
+            var unbindCmd = new Command("unbind", "Remove a Microsoft account binding for a tenant or Azure DevOps organization");
+            var unbindTenantOpt = new Option<string>("--tenant", "Remove the binding for the given Microsoft Entra tenant");
+            var unbindOrgOpt = new Option<string>("--org", "Remove the binding for the given Azure DevOps organization");
+            unbindCmd.AddOption(unbindTenantOpt);
+            unbindCmd.AddOption(unbindOrgOpt);
             unbindCmd.AddOption(localOpt);
-            unbindCmd.SetHandler(UnbindCmd, orgArg, localOpt);
+            unbindCmd.SetHandler(UnbindCmd, unbindTenantOpt, unbindOrgOpt, localOpt);
 
             var rootCmd = new ProviderCommand(this);
             rootCmd.AddCommand(loginCmd);
@@ -1045,15 +1094,44 @@ namespace Microsoft.AzureRepos
             public Uri Uri { get; set; }
         }
 
-        private void ListBindingsCmd(string organization, bool showRemotes, bool verbose)
+        private async Task<int> ListBindingsCmd(string organization, bool showRemotes, bool verbose)
         {
-            // Get all organization bindings from the user manager
-            IList<AzureReposBinding> bindings = _bindingManager.GetBindings(organization).ToList();
-            IDictionary<string, IEnumerable<AzureReposBinding>> orgBindingMap =
-                bindings.GroupBy(x => x.Organization).ToDictionary();
+            // Group bindings into per-scope-key buckets so we can render one heading per
+            // tenant/org with its global and local bindings beneath.
+            var byHeading = new SortedDictionary<string, (IMicrosoftAccount Global, IMicrosoftAccount Local)>(StringComparer.OrdinalIgnoreCase);
+            foreach (AzureReposBinding b in _bindingManager.GetBindings())
+            {
+                string heading = b.Scope switch
+                {
+                    AzureReposBindingScope.Org o    => $"dev.azure.com/{o.OrgName}",
+                    AzureReposBindingScope.Tenant t => $"login.microsoftonline.com/{t.TenantId}",
+                    _ => null,
+                };
+                if (heading is null) continue;
+                if (!string.IsNullOrWhiteSpace(organization) &&
+                    b.Scope is AzureReposBindingScope.Org filterOrg &&
+                    !StringComparer.OrdinalIgnoreCase.Equals(filterOrg.OrgName, organization))
+                {
+                    continue;
+                }
+                if (!byHeading.TryGetValue(heading, out var pair)) pair = (null, null);
+                if (b.Scope.IsLocal) pair.Local = b.Account; else pair.Global = b.Account;
+                byHeading[heading] = pair;
+            }
 
-            // If we are asked to also show remotes we build the remote binding map
-            var orgRemotesMap = new Dictionary<string, ICollection<RemoteBinding>>();
+            // Cache MSAL accounts once so we can enrich legacy `.accountid`-only bindings with
+            // a UPN for display. New bindings carry both fields and don't need this lookup.
+            IReadOnlyList<IMicrosoftAccount> cached =
+                await _msAuth.GetUserAccountsAsync(GetClientId(), msaPt: true);
+            var upnByAccountId = cached.ToDictionary(a => a.HomeAccountId, a => a.UserName, StringComparer.OrdinalIgnoreCase);
+            string Display(IMicrosoftAccount a)
+            {
+                if (a is null) return null;
+                if (!string.IsNullOrWhiteSpace(a.UserName)) return a.UserName;
+                return upnByAccountId.TryGetValue(a.HomeAccountId, out string upn) ? upn : a.HomeAccountId;
+            }
+
+            var orgRemotes = new Dictionary<string, ICollection<RemoteBinding>>();
             if (showRemotes)
             {
                 if (!_context.Git.IsInsideRepository())
@@ -1074,109 +1152,146 @@ namespace Microsoft.AzureRepos
                     if (IsAzureDevOpsHttpRemote(remote.FetchUrl, out Uri fetchUri))
                     {
                         string fetchOrg = UriHelpers.GetOrganizationName(fetchUri);
-                        var binding = new RemoteBinding {IsPush = false, Remote = remote.Name, Uri = fetchUri};
-                        orgRemotesMap.Append(fetchOrg, binding);
+                        orgRemotes.Append($"dev.azure.com/{fetchOrg}",
+                            new RemoteBinding { IsPush = false, Remote = remote.Name, Uri = fetchUri });
                     }
-
                     if (IsAzureDevOpsHttpRemote(remote.PushUrl, out Uri pushUri))
                     {
                         string pushOrg = UriHelpers.GetOrganizationName(pushUri);
-                        var binding = new RemoteBinding {IsPush = true, Remote = remote.Name, Uri = pushUri};
-                        orgRemotesMap.Append(pushOrg, binding);
+                        orgRemotes.Append($"dev.azure.com/{pushOrg}",
+                            new RemoteBinding { IsPush = true, Remote = remote.Name, Uri = pushUri });
                     }
                 }
             }
 
-            bool isFiltered = !string.IsNullOrWhiteSpace(organization);
-            string indent = isFiltered ? string.Empty : "  ";
-
-            // Get the set of all organization names (organization names are not case sensitive)
-            ISet<string> orgNames = new HashSet<string>(orgBindingMap.Keys, StringComparer.OrdinalIgnoreCase);
-            orgNames.UnionWith(orgRemotesMap.Keys);
+            var headings = new SortedSet<string>(byHeading.Keys, StringComparer.OrdinalIgnoreCase);
+            headings.UnionWith(orgRemotes.Keys);
 
             var icmp = StringComparer.OrdinalIgnoreCase;
-
-            foreach (string orgName in orgNames)
+            foreach (string heading in headings)
             {
-                if (!isFiltered)
-                {
-                    _context.Console.WriteLine($"{orgName}:");
-                }
+                _context.Streams.Out.WriteLine($"{heading}:");
 
-                // Print organization bindings
-                foreach (AzureReposBinding binding in orgBindingMap.GetValues(orgName))
+                if (byHeading.TryGetValue(heading, out var pair))
                 {
-                    if (binding.GlobalUserName != null)
+                    if (pair.Global != null)
                     {
-                        _context.Console.WriteLine($"{indent}(global) -> {binding.GlobalUserName}");
+                        _context.Streams.Out.WriteLine($"  (global) -> {Display(pair.Global)}");
                     }
-
-                    if (binding.LocalUserName != null)
+                    if (pair.Local != null)
                     {
-                        string value = string.IsNullOrEmpty(binding.LocalUserName)
-                            ? "(no inherit)"
-                            : binding.LocalUserName;
-                        _context.Console.WriteLine($"{indent}(local)  -> {value}");
+                        _context.Streams.Out.WriteLine($"  (local)  -> {Display(pair.Local)}");
                     }
                 }
 
-                // Print remote bindings
-                IEnumerable<IGrouping<string, RemoteBinding>> remoteBindingMap =
-                    orgRemotesMap.GetValues(orgName).GroupBy(x => x.Remote);
+                if (!orgRemotes.TryGetValue(heading, out var remotes)) continue;
 
-                foreach (var remoteBinding in remoteBindingMap)
+                IEnumerable<IGrouping<string, RemoteBinding>> byRemote = remotes.GroupBy(r => r.Remote);
+                string orgForRemote = heading.StartsWith("dev.azure.com/", StringComparison.OrdinalIgnoreCase)
+                    ? heading.Substring("dev.azure.com/".Length)
+                    : null;
+                foreach (var group in byRemote)
                 {
-                    _context.Console.WriteLine($"{indent}{remoteBinding.Key}:");
-                    foreach (RemoteBinding binding in remoteBinding)
+                    _context.Streams.Out.WriteLine($"  {group.Key}:");
+                    foreach (RemoteBinding rb in group)
                     {
-                        // User names in dev.azure.com URLs cannot always be used as *actual user names*
-                        // because of the unfortunate decision to use this field to get the Azure DevOps
-                        // organization name to be sent by Git to credential helpers.
-                        //
-                        // We show dev.azure.com URLs as "inherit", if there is a username that matches
-                        // the organization name.
-                        if (!binding.Uri.TryGetUserInfo(out string userName, out _) ||
-                            UriHelpers.IsDevAzureComHost(binding.Uri.Host) && icmp.Equals(userName, orgName))
+                        // dev.azure.com URLs use the user-info slot to carry the org name; ignore that
+                        // pseudo-user when reporting the remote's preferred account.
+                        if (!rb.Uri.TryGetUserInfo(out string remoteUser, out _) ||
+                            (UriHelpers.IsDevAzureComHost(rb.Uri.Host) &&
+                             orgForRemote != null && icmp.Equals(remoteUser, orgForRemote)))
                         {
-                            userName = "(inherit)";
+                            remoteUser = "(inherit)";
                         }
 
-                        string url = null;
-                        if (verbose)
-                        {
-                            url = $"{binding.Uri.WithoutUserInfo()} ";
-                        }
-
-                        _context.Console.WriteLine(binding.IsPush
-                            ? $"{indent}  {url}(push)  -> {userName}"
-                            : $"{indent}  {url}(fetch) -> {userName}");
+                        string url = verbose ? $"{rb.Uri.WithoutUserInfo()} " : null;
+                        _context.Streams.Out.WriteLine(rb.IsPush
+                            ? $"    {url}(push)  -> {remoteUser}"
+                            : $"    {url}(fetch) -> {remoteUser}");
                     }
                 }
             }
+
+            return 0;
         }
 
-        private Task<int> BindCmd(string organization, string userName, bool local)
+        private async Task<int> BindCmd(string account, string tenantId, string orgName, bool local)
         {
-            if (local && !_context.Git.IsInsideRepository())
+            if (!TryParseBindingScope(tenantId, orgName, local, out AzureReposBindingScope scope, out string error))
             {
-                _context.Console.WriteError("not inside a git repository (cannot use --local)");
+                _context.Streams.Error.WriteLine(error);
+                return -1;
+            }
+
+            if (string.IsNullOrWhiteSpace(account))
+            {
+                _context.Streams.Error.WriteLine("error: account is required");
+                return -1;
+            }
+
+            // Look the account up in the MSAL cache. If found, bind the cached account directly
+            // — it carries both a UPN and a stable HomeAccountId. If not found we warn but still
+            // record a UPN-or-HomeAccountId binding from whatever the user supplied; one classify
+            // here decides which field of the IMicrosoftAccount we populate.
+            IReadOnlyList<IMicrosoftAccount> cached =
+                await _msAuth.GetUserAccountsAsync(GetClientId(), msaPt: true);
+            IMicrosoftAccount match = cached.FirstOrDefault(a =>
+                StringComparer.OrdinalIgnoreCase.Equals(a.UserName, account) ||
+                StringComparer.Ordinal.Equals(a.HomeAccountId, account));
+            IMicrosoftAccount toBind;
+            if (match != null)
+            {
+                toBind = match;
+            }
+            else
+            {
+                _context.Streams.Error.WriteLine(
+                    $"warning: '{account}' is not in the MSAL cache. Recording the binding anyway; "
+                    + "run `azure-repos login` first to sign in.");
+                toBind = MicrosoftAccount.FromIdentifier(account);
+            }
+
+            _bindingManager.Bind(scope, toBind);
+            return 0;
+        }
+
+        private Task<int> UnbindCmd(string tenantId, string orgName, bool local)
+        {
+            if (!TryParseBindingScope(tenantId, orgName, local, out AzureReposBindingScope scope, out string error))
+            {
+                _context.Streams.Error.WriteLine(error);
                 return Task.FromResult(-1);
             }
 
-            _bindingManager.Bind(organization, userName, local);
+            _bindingManager.Unbind(scope);
             return Task.FromResult(0);
         }
 
-        private Task<int> UnbindCmd(string organization, bool local)
+        private bool TryParseBindingScope(
+            string tenantId, string orgName, bool local,
+            out AzureReposBindingScope scope, out string error)
         {
-            if (local && !_context.Git.IsInsideRepository())
+            scope = null;
+            error = null;
+
+            int specified = (string.IsNullOrWhiteSpace(tenantId) ? 0 : 1)
+                          + (string.IsNullOrWhiteSpace(orgName) ? 0 : 1);
+            if (specified != 1)
             {
-                _context.Console.WriteError("not inside a git repository (cannot use --local)");
-                return Task.FromResult(-1);
+                error = "error: specify exactly one of --tenant or --org";
+                return false;
             }
 
-            _bindingManager.Unbind(organization, local);
-            return Task.FromResult(0);
+            if (local && !_context.Git.IsInsideRepository())
+            {
+                error = "error: not inside a git repository (cannot use --local)";
+                return false;
+            }
+
+            scope = !string.IsNullOrWhiteSpace(tenantId)
+                ? AzureReposBindingScope.ForTenant(tenantId, local)
+                : AzureReposBindingScope.ForOrg(orgName, local);
+            return true;
         }
 
         #endregion


### PR DESCRIPTION
Refs: #2057

## Summary

Builds on the `IMicrosoftAuthentication` reshape (#22 — `msauth-newapi` → `new-protocol`) to deliver the first user-visible feature it unlocks: a clearer Microsoft account model for Azure Repos.

Today the Azure Repos provider conflates "which Microsoft identities does GCM have credentials for" with "which identity should I use for this organization". Both layers live in the same `AzureReposBindingManager`, both are keyed by UPN, and neither is directly inspectable. This PR splits the two concerns:

- **Accounts**: identities GCM holds Microsoft credentials for. Source of truth is the MSAL cache. New `azure-repos login` / `logout` / `list` commands manage this pool directly, mirroring `gh auth login` / `az login` vocabulary.
- **Bindings**: pure preferences saying "for this scope, prefer this account". The binding manager itself trafficks in `IMicrosoftAccount`, storing the MSAL `HomeAccountId` (stable across UPN renames) and the UPN side-by-side under a new scope union (`Tenant` / `Org` × `IsLocal`). Resolution layers most-specific-first.

With the underlying API now speaking in `IMicrosoftAccount` end-to-end (from the prerequisite PR), the binding manager can pass account records straight through to msauth — no UPN ↔ HomeAccountId translation glue at the provider boundary.

No protocol-layer features (`state[]` retry loops, prompt-and-remember pickers) are wired up in this PR — that's the next layer. This is the data model and verb surface they'll build on.

## What's in this PR

Three commits, ordered as a readable story.

1. **`azrepos: migrate to IMicrosoftAccount and drop the obsolete msauth extension`**
   The Azure Repos OAuth path is the only production caller of the now-obsolete `string userName` overload of `GetTokenForUserAsync` in the tree, so migrate it and delete the obsolete extension in the same commit. `GetAzureAccessTokenAsync` constructs an `IMicrosoftAccount` from the resolved UPN (or `null` when no UPN was resolved) and passes it to the new interface overload directly; with the caller migrated, `MicrosoftAuthenticationExtensions` has no remaining users and disappears. The interface is now the single shape callers talk to, with no parallel API to drift against.

2. **`azrepos: add login/logout/list for Microsoft accounts and rename list to list-bindings`**
   Splits the verb surface into two clusters:

   - `login [--tenant <id|domain>]`, `logout (<account> | --all)`, `list` — operate on the MSAL account pool only. They do not touch the binding manager. `login` defaults to the `organizations` authority (work/school account picker); `--tenant` exists primarily to pre-stage a guest-account record when the home tenant differs from the tenant you want to use it for.
   - `bind`, `unbind`, `list-bindings` — manage which account a particular ADO tenant or org should use. `list-bindings` is what `list` used to be (pure rename of the binding view).

   The names were previously overloaded: the old `list` showed bindings, there was no equivalent of `gh auth status`, and signing in or out was an implicit side effect of bind/unbind. Splitting matches the vocabulary of comparable tools (`az login`, `gh auth login`).

3. **`azrepos: rebuild binding manager around scopes and home account id`**
   The marquee commit. The pre-rewrite binding manager had one stored shape — `(orgName, userName)` — and one verb pair to manipulate it. It could not distinguish "use account A for any org in tenant T" from "use account A for org O", and the stored value was a UPN, so a rename outside GCM silently broke the binding.

   Rebuild around:

   - **Scope union.** `AzureReposBindingScope` is a sealed discriminated union of `Tenant(id)` and `Org(name)`, each carrying an `IsLocal` flag that picks per-clone vs. machine-wide storage. Resolution is most-specific-first: local Org → global Org → local Tenant → global Tenant → nothing.
   - **`IMicrosoftAccount`-typed API.** The manager takes `IMicrosoftAccount` on `Bind` and returns one from `GetAccount`, so the storage boundary owns the UPN-vs-HomeAccountId distinction and the provider doesn't have to encode-then-translate at the cache boundary.
   - **Dual-key storage.** `.accountid` always holds the MSAL `HomeAccountId`, `.username` always holds the UPN. Both are written atomically when both are known; either alone when only one is available. Legacy `.username`-only bindings from older releases continue to read back as a UPN-only account and migrate to the new shape on the next rewrite. No format detection on write, no drift warning on read — with atomic dual-key writes both keys present is the normal, fully-resolved state.
   - **`MicrosoftAccount.FromIdentifier` factory.** New public API on `MicrosoftAccount` (Core) that classifies a single user-typed string into the matching slot: an Entra `<object-id>.<tenant-id-guid>` shape (split on the last `.`, mirroring `Microsoft.Identity.Client.AccountId.ParseFromString`, with only the tenant-id side required to be a GUID) lands in `HomeAccountId`; anything else (UPNs, bare words, ADFS-style single tokens) lands in `UserName`. Used everywhere the provider previously had to decide which slot a raw string belongs in — CLI `bind`, URL/credential `username` on `get`, and `store` cache-miss fallback all go through the same factory.

   `bind`/`unbind` are reshaped: `bind <account> (--tenant <id> | --org <name>) [--local]` and `unbind (--tenant <id> | --org <name>) [--local]`. `<account>` is matched against the MSAL cache by either UPN or HomeAccountId; on a cache miss the value is classified by `MicrosoftAccount.FromIdentifier` and persisted as-is, so a clone can be pinned to a specific MSAL account by either UPN or HomeAccountId. The `NoInherit` sentinel from the old manager is dropped — with bindings now resolved by an explicit hierarchy, a per-clone "always prompt" toggle is better delivered through a future picker UI than as a magic empty string.

   Credential get/store/erase paths integrate with the new resolver; `list-bindings` learns to group under scope-derived headings (`dev.azure.com/<org>`, `login.microsoftonline.com/<tenant-id>`). Tests cover the new storage shape (HomeAccountId-only, UPN-only, and both fields), legacy `.username`-only fallback at both Tenant and Org scopes, scope/level resolution precedence, the `FromIdentifier` factory (classic Entra GUID.GUID, non-GUID object id, ambiguous-as-UPN, malformed-tenant rejection, null/whitespace rejection), and a new `DevAzureUrlHomeAccountId` `GetCredentialAsync` test pinning the URL-user classification.

## What this enables (deliberately *not* in this PR)

Each of these belongs in a follow-up PR that ships a concrete user-visible win on top of this foundation:

- **Account picker UI.**
  Avalonia + terminal fallback for the multi-candidate case (when more than one cached account matches the request's tenant, or none does and the user needs to pick or sign in). The new account-pool surface is where the picker reads its options from.

- **State-aware get + prompt-and-remember + optimistic auto-route.**
  Now that `state[]` and `continue` are live (from the underlying `new-protocol` PR), the AzRepos provider can return a token optimistically (e.g. the only cached account in the request's tenant), record which account it tried in state, and pick a different one on a 401 — escaping the "wrong cached account is the only candidate" trap that a naive single-match auto-route would create. The picker grows a "remember this choice" checkbox whose result is threaded through state and persisted on the next `store` — so a binding is only written when the chosen credential actually worked.

- **Friendly tenant names.**
  Today `list-bindings` shows raw tenant GUIDs under the `login.microsoftonline.com/<id>` heading. A Graph-based lookup can map those to display names; deferred until there's a clear cache story.

## Compatibility

- **Existing `.username` bindings from older releases.**
  Read transparently as a fallback when no `.accountid` exists at the same scope (Org *and* Tenant scopes — the legacy storage was Org-only in older releases, but the fallback is symmetric now). The first time a binding is rewritten (via `bind`, or implicitly via `store`), it migrates to `.accountid` keyed by HomeAccountId.

- **Existing `bind <org> <username>` CLI syntax.**
  Breaking. `bind` and `unbind` now take `--tenant`/`--org`/`--local` flags and a single positional `<account>`. The old positional `<organization> <username>` form is gone. `vnext` is still pre-release and the verb surface needed to align with the new identity model; a deprecation period would have lived in an awkward shape.

- **`azure-repos list` output.**
  Breaking. `list` now shows MSAL-cached accounts; the binding view moved to `list-bindings`. Scripts parsing the old format need to switch verb.

- **`MicrosoftAuthenticationExtensions` deletion.**
  Out-of-tree callers that depended on the obsolete `string userName` overload of `GetTokenForUserAsync` (added in the prerequisite PR) now need to construct an `IMicrosoftAccount`. The in-tree migration and deletion happen together in commit 1.

## Testing

- Full unit test suite passes (Core, AzureRepos, GitHub, Bitbucket, GitLab) — 1322 tests, 0 failures.
- New test coverage for the binding manager: HomeAccountId-only, UPN-only, and dual-field bind shapes; legacy `.username`-only read fallback at both Tenant and Org scopes; local-vs-global enumeration boundaries; and the layered resolution hierarchy across scopes and levels.
- New test coverage for `MicrosoftAccount.FromIdentifier` in Core: classic Entra (GUID.GUID), non-GUID object id (B2C / multi-dot shapes), ambiguous-as-UPN cases, malformed-tenant rejection, and null/whitespace rejection.
- `AzureReposHostProviderTests` updated to the new mock surface (`GetAccount(scope)` returning `IMicrosoftAccount`), with a new `DevAzureUrlHomeAccountId` test pinning the URL-user classification.
- Manually smoke-tested `azure-repos list` against a live MSAL cache with multiple accounts.

## Notes for reviewers

- Reviewing commit-by-commit is recommended. The chain is deliberately ordered so each commit tells one story; the squashed diff hides the consumer-migration → product-change progression.
- Each commit builds cleanly and tests pass at every step.
- The binding manager's "no translation helpers" property is the headline cleanliness win. The previous draft of this work had a `TranslateUpnToAccountIdAsync` / `TranslateAccountIdToUpnAsync` pair gluing the binding store to the auth API; with msauth taking `IMicrosoftAccount` natively (from the prerequisite PR) those helpers don't exist.
- `MicrosoftAccount.FromIdentifier` is the one new piece of *Core* (non-AzRepos) public surface introduced by this PR. It exists because three sites in the AzRepos provider need to classify a single string into the right `IMicrosoftAccount` slot; consolidating the heuristic on the type that owns the two slots keeps the provider out of the classification business and gives follow-up consumers (eg. the account picker UI) one place to reuse.

Builds on #22. Closes part of #2057.
