### PR TITLE
build: drop the .NET Framework target

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,9 +60,9 @@ jobs:
       shell: bash
       run: |
         mkdir -p artifacts/bin
-        mv out/windows/Installer.Windows/bin/Release/net472/gcm*.exe artifacts/
-        mv out/windows/Installer.Windows/bin/Release/net472/${{ matrix.runtime }} artifacts/bin/
-        cp out/windows/Installer.Windows/bin/Release/net472/${{ matrix.runtime }}.sym/* artifacts/bin/${{ matrix.runtime }}/
+        mv out/windows/Installer.Windows/bin/Release/net10.0/gcm*.exe artifacts/
+        mv out/windows/Installer.Windows/bin/Release/net10.0/${{ matrix.runtime }} artifacts/bin/
+        cp out/windows/Installer.Windows/bin/Release/net10.0/${{ matrix.runtime }}.sym/* artifacts/bin/${{ matrix.runtime }}/
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v7

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,8 +26,4 @@
     <GenerateWindowsAppManifest Condition="'$(GenerateWindowsAppManifest)' == '' AND '$(OSPlatform)' == 'windows' AND '$(_IsExeProject)' == 'true'">true</GenerateWindowsAppManifest>
   </PropertyGroup>
 
-  <ItemGroup Condition = "'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
-
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -14,6 +14,14 @@
     </GetVersion>
   </Target>
 
+  <!-- Suppress the "This call site is reachable on all platforms" warning
+       for all test projects - we use custom Xunit attributes to dynamically
+       skip OS-specific tests unless the test is running on the appropriate OS.
+       The analyzer for CA1416 does not know how to handle this. -->
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
   <!-- Windows application manifest generation -->
   <PropertyGroup Condition="'$(GenerateWindowsAppManifest)' != 'false'">
     <ApplicationManifest>$(IntermediateOutputPath)app.manifest</ApplicationManifest>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,7 @@
     <PackageVersion Include="Avalonia" Version="11.1.3" />
     <PackageVersion Include="Avalonia.Desktop" Version="11.1.3" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.1.3" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Win32" Version="11.1.3" />
 
     <!-- Microsoft Identity -->
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.65.0" />

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,9 +40,9 @@ To build from the command line, run:
 dotnet build -c WindowsDebug
 ```
 
-You can find a copy of the installer .exe file in `out\windows\Installer.Windows\bin\Debug\net472`.
+You can find a copy of the installer .exe file in `out\windows\Installer.Windows\bin\Debug\net10.0`.
 
-The flat binaries can also be found in `out\windows\Payload.Windows\bin\Debug\net472\win-x86`.
+The flat binaries can also be found in `out\windows\Payload.Windows\bin\Debug\net10.0\win-x86`.
 
 ### Linux
 

--- a/src/shared/Atlassian.Bitbucket/Atlassian.Bitbucket.csproj
+++ b/src/shared/Atlassian.Bitbucket/Atlassian.Bitbucket.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net10.0;net472</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Atlassian.Bitbucket</AssemblyName>
     <RootNamespace>Atlassian.Bitbucket</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -11,10 +10,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -60,11 +60,7 @@ namespace GitCredentialManager.Authentication
             // Write the standard input to the process if we have any to write
             if (standardInput is not null)
             {
-#if NETFRAMEWORK
-                await standardInput.BaseStream.CopyToAsync(process.StandardInput.BaseStream);
-#else
                 await standardInput.BaseStream.CopyToAsync(process.StandardInput.BaseStream, ct);
-#endif
                 process.StandardInput.Close();
             }
 

--- a/src/shared/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Core/Authentication/MicrosoftAuthentication.cs
@@ -16,10 +16,7 @@ using GitCredentialManager.UI.Controls;
 using GitCredentialManager.UI.ViewModels;
 using GitCredentialManager.UI.Views;
 using Microsoft.Identity.Client.AppConfig;
-
-#if NETFRAMEWORK
 using Microsoft.Identity.Client.Broker;
-#endif
 
 namespace GitCredentialManager.Authentication
 {
@@ -598,7 +595,6 @@ namespace GitCredentialManager.Authentication
             // to save on the distribution size of the .NET builds (no need for MSALRuntime bits).
             if (enableBroker)
             {
-#if NETFRAMEWORK
                 appBuilder.WithBroker(
                     new BrokerOptions(BrokerOptions.OperatingSystems.Windows)
                     {
@@ -606,7 +602,6 @@ namespace GitCredentialManager.Authentication
                         MsaPassthrough = msaPt,
                     }
                 );
-#endif
             }
 
             IPublicClientApplication app = appBuilder.Build();
@@ -939,9 +934,8 @@ namespace GitCredentialManager.Authentication
 
         public bool CanUseBroker()
         {
-#if NETFRAMEWORK
             // We only support the broker on Windows 10+ and in an interactive session
-            if (!Context.SessionManager.IsDesktopSession || !PlatformUtils.IsWindowsBrokerSupported())
+            if (!PlatformUtils.IsWindowsBrokerSupported() || !Context.SessionManager.IsDesktopSession)
             {
                 return false;
             }
@@ -958,34 +952,26 @@ namespace GitCredentialManager.Authentication
             }
 
             return defaultValue;
-#else
-            // OS broker requires .NET Framework right now until we migrate to .NET 5.0 (net5.0-windows10.x.y.z)
-            return false;
-#endif
         }
 
         private bool CanUseEmbeddedWebView()
         {
-            // If we're in an interactive session and on .NET Framework then MSAL can show the WinForms-based embedded UI
-#if NETFRAMEWORK
-            return Context.SessionManager.IsDesktopSession;
-#else
+            // TODO: check for desktop session once embedded web view is added back
+            // return Context.SessionManager.IsDesktopSession;
             return false;
-#endif
         }
 
         private void EnsureCanUseEmbeddedWebView()
         {
-#if NETFRAMEWORK
-            if (!Context.SessionManager.IsDesktopSession)
-            {
-                throw new Trace2InvalidOperationException(Context.Trace2,
-                    "Embedded web view is not available without a desktop session.");
-            }
-#else
+            // TODO: check for desktop session once embedded web view is added back
+            // if (!Context.SessionManager.IsDesktopSession)
+            // {
+            //     throw new Trace2InvalidOperationException(Context.Trace2,
+            //         "Embedded web view is not available without a desktop session.");
+            // }
+
             throw new Trace2InvalidOperationException(Context.Trace2,
                 "Embedded web view is not available on .NET Core.");
-#endif
         }
 
         private bool CanUseSystemWebView(IPublicClientApplication app, Uri redirectUri)

--- a/src/shared/Core/CommandContext.cs
+++ b/src/shared/Core/CommandContext.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using GitCredentialManager.Interop.Linux;

--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net10.0;net472</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>gcmcore</AssemblyName>
     <RootNamespace>GitCredentialManager</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -10,23 +9,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
-    <PackageReference Include="Microsoft.Identity.Client.Broker" />
-    <PackageReference Include="Avalonia.Win32" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
-    <PackageReference Include="Avalonia.Desktop" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Avalonia" />
-    <PackageReference Include="Avalonia.Skia" />
+    <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
   </ItemGroup>
 

--- a/src/shared/Core/CurlCookie.cs
+++ b/src/shared/Core/CurlCookie.cs
@@ -66,11 +66,7 @@ namespace GitCredentialManager
 
         private static DateTime ParseExpires(string expires)
         {
-#if NETFRAMEWORK
-            DateTime epoch = new DateTime(1970, 01, 01, 0, 0, 0, DateTimeKind.Utc);
-#else
             DateTime epoch = DateTime.UnixEpoch;
-#endif
 
             if (long.TryParse(expires, out long i))
             {

--- a/src/shared/Core/FileSystem.cs
+++ b/src/shared/Core/FileSystem.cs
@@ -130,9 +130,6 @@ namespace GitCredentialManager
 
         public bool FileExists(string path) => File.Exists(path);
 
-#if NETFRAMEWORK
-        public bool FileIsExecutable(string path) => true;
-#else
         public bool FileIsExecutable(string path)
         {
             if (!PlatformUtils.IsPosix())
@@ -145,7 +142,6 @@ namespace GitCredentialManager
                             UnixFileMode.OtherExecute)) != 0;
 #pragma warning restore CA1416
         }
-#endif
 
         public bool DirectoryExists(string path) => Directory.Exists(path);
 

--- a/src/shared/Core/GitCapabilities.cs
+++ b/src/shared/Core/GitCapabilities.cs
@@ -114,11 +114,8 @@ public static class GitCapabilitiesUtils
         {
             yield break;
         }
-#if NETFRAMEWORK
-        foreach (GitCapabilities flag in (GitCapabilities[])Enum.GetValues(typeof(GitCapabilities)))
-#else
+
         foreach (GitCapabilities flag in Enum.GetValues<GitCapabilities>())
-#endif
         {
             if (flag == GitCapabilities.None)
             {

--- a/src/shared/Core/GitResponse.cs
+++ b/src/shared/Core/GitResponse.cs
@@ -180,11 +180,7 @@ public class GitResponse
     /// silently no-ops and this view stays empty.
     /// </para>
     /// </remarks>
-#if NETFRAMEWORK
-    public IReadOnlyDictionary<string, string> State => _stateView ??= new ReadOnlyDictionary<string, string>(_state);
-#else
     public IReadOnlyDictionary<string, string> State => _stateView ??= _state.AsReadOnly();
-#endif
 
     /// <summary>
     /// Set a single state entry.

--- a/src/shared/Core/GitStreamReader.cs
+++ b/src/shared/Core/GitStreamReader.cs
@@ -18,18 +18,10 @@ public class GitStreamReader : StreamReader
 
     public override string ReadLine()
     {
-#if NETFRAMEWORK
-        return ReadLineAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-#else
         return ReadLineAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
-#endif
     }
 
-#if NETFRAMEWORK
-    public override async Task<string> ReadLineAsync()
-#else
     public override async ValueTask<string> ReadLineAsync(CancellationToken cancellationToken)
-#endif
     {
         int nr;
         var sb = new StringBuilder();

--- a/src/shared/Core/HttpClientFactory.cs
+++ b/src/shared/Core/HttpClientFactory.cs
@@ -99,11 +99,7 @@ namespace GitCredentialManager
                 _streams.Error.WriteLine("warning: ---------------------------------------------------");
                 _streams.Error.WriteLine($"warning: HTTPS connections may not be secure. See {Constants.HelpUrls.GcmTlsVerification} for more information.");
 
-#if NETFRAMEWORK
-                ServicePointManager.ServerCertificateValidationCallback = (req, cert, chain, errors) => true;
-#else
                 handler.ServerCertificateCustomValidationCallback = (req, cert, chain, errors) => true;
-#endif
             }
             // If schannel is the TLS backend, custom certificate usage must be explicitly enabled
             else if (!string.IsNullOrWhiteSpace(_settings.CustomCertificateBundlePath) &&
@@ -130,11 +126,7 @@ namespace GitCredentialManager
 
                     // Import the custom certs
                     X509Certificate2Collection certBundle = new X509Certificate2Collection();
-#if NETFRAMEWORK
-                    certBundle.Import(certBundlePath);
-#else
                     certBundle.ImportFromPemFile(certBundlePath);
-#endif
 
                     try
                     {
@@ -182,23 +174,7 @@ namespace GitCredentialManager
 
                 // Set the custom server certificate validation callback.
                 // NOTE: this is executed after the default platform server certificate validation is performed
-#if NETFRAMEWORK
-                ServicePointManager.ServerCertificateValidationCallback = (_, cert, chain, errors) =>
-                {
-                    // Fail immediately if the cert or chain isn't present
-                    if (cert is null || chain is null)
-                    {
-                        return false;
-                    }
-
-                    using (X509Certificate2 cert2 = new X509Certificate2(cert))
-                    {
-                        return validationCallback(cert2, chain, errors);
-                    }
-                };
-#else
                 handler.ServerCertificateCustomValidationCallback = (_, cert, chain, errors) => validationCallback(cert, chain, errors);
-#endif
             }
 
             // If CustomCookieFilePath is set, set Cookie header from cookie file, which is written by libcurl

--- a/src/shared/Core/Interop/Linux/LinuxConfigParser.cs
+++ b/src/shared/Core/Interop/Linux/LinuxConfigParser.cs
@@ -6,15 +6,9 @@ namespace GitCredentialManager.Interop.Linux;
 
 public class LinuxConfigParser
 {
-#if NETFRAMEWORK
-    private const string SQ = "'";
-    private const string DQ = "\"";
-    private const string Hash = "#";
-#else
     private const char SQ = '\'';
     private const char DQ = '"';
     private const char Hash = '#';
-#endif
 
     private static readonly Regex LineRegex = new(@"^\s*(?<key>[a-zA-Z0-9\.-]+)\s*=\s*(?<value>.+?)\s*(?:#.*)?$");
 

--- a/src/shared/Core/Interop/Linux/LinuxFileSystem.cs
+++ b/src/shared/Core/Interop/Linux/LinuxFileSystem.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Posix;
 
 namespace GitCredentialManager.Interop.Linux
 {
+    [SupportedOSPlatform("linux")]
     public class LinuxFileSystem : PosixFileSystem
     {
         public override bool IsSamePath(string a, string b)

--- a/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
+++ b/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Posix;
 
 namespace GitCredentialManager.Interop.Linux;
 
+[SupportedOSPlatform("linux")]
 public class LinuxSessionManager : PosixSessionManager
 {
     private bool? _isWebBrowserAvailable;

--- a/src/shared/Core/Interop/Linux/LinuxSettings.cs
+++ b/src/shared/Core/Interop/Linux/LinuxSettings.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Text;
-using Avalonia.Markup.Xaml.MarkupExtensions;
 
 namespace GitCredentialManager.Interop.Linux;
 
+[SupportedOSPlatform("linux")]
 public class LinuxSettings : Settings
 {
     private readonly ITrace _trace;

--- a/src/shared/Core/Interop/Linux/LinuxTerminal.cs
+++ b/src/shared/Core/Interop/Linux/LinuxTerminal.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Linux.Native;
 using GitCredentialManager.Interop.Posix;
 using GitCredentialManager.Interop.Posix.Native;
 
 namespace GitCredentialManager.Interop.Linux
 {
+    [SupportedOSPlatform("linux")]
     public class LinuxTerminal : PosixTerminal
     {
         public LinuxTerminal(ITrace trace, ITrace2 trace2)

--- a/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
@@ -1,12 +1,11 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Threading;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Posix;
 
 namespace GitCredentialManager.Interop.MacOS
 {
+    [SupportedOSPlatform("macos")]
     public class MacOSEnvironment : PosixEnvironment
     {
         private ICollection<string> _pathsToIgnore;

--- a/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Posix;
 
 namespace GitCredentialManager.Interop.MacOS
 {
+    [SupportedOSPlatform("macos")]
     public class MacOSFileSystem : PosixFileSystem
     {
         public override bool IsSamePath(string a, string b)

--- a/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs
@@ -1,8 +1,10 @@
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.MacOS.Native;
 using GitCredentialManager.Interop.Posix;
 
 namespace GitCredentialManager.Interop.MacOS
 {
+    [SupportedOSPlatform("macos")]
     public class MacOSSessionManager : PosixSessionManager
     {
         public MacOSSessionManager(ITrace trace, IEnvironment env, IFileSystem fs) : base(trace, env, fs)

--- a/src/shared/Core/Interop/MacOS/MacOSSettings.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSSettings.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 
 namespace GitCredentialManager.Interop.MacOS
 {
     /// <summary>
     /// Reads settings from Git configuration, environment variables, and defaults from the system.
     /// </summary>
+    [SupportedOSPlatform("macos")]
     public class MacOSSettings : Settings
     {
         private readonly ITrace _trace;

--- a/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.MacOS.Native;
 using GitCredentialManager.Interop.Posix;
 using GitCredentialManager.Interop.Posix.Native;
 
 namespace GitCredentialManager.Interop.MacOS
 {
+    [SupportedOSPlatform("macos")]
     public class MacOSTerminal : PosixTerminal
     {
         public MacOSTerminal(ITrace trace, ITrace2 trace2)

--- a/src/shared/Core/Interop/Posix/PosixEnvironment.cs
+++ b/src/shared/Core/Interop/Posix/PosixEnvironment.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Runtime.Versioning;
 
 namespace GitCredentialManager.Interop.Posix
 {
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("linux")]
     public class PosixEnvironment : EnvironmentBase
     {
         public PosixEnvironment(IFileSystem fileSystem)

--- a/src/shared/Core/Interop/Posix/PosixFileSystem.cs
+++ b/src/shared/Core/Interop/Posix/PosixFileSystem.cs
@@ -13,13 +13,6 @@ namespace GitCredentialManager.Interop.Posix
         /// <exception cref="ArgumentException">Path is not absolute.</exception>
         protected internal static string ResolveSymbolicLinks(string path)
         {
-#if NETFRAMEWORK
-            // Support for symlinks only exists in .NET 6+.
-            // Since we're still targeting .NET Framework on Windows it
-            // doesn't matter if we don't resolve symlinks for POSIX here
-            // (unless we're running on Mono.. but why do that?)
-            return path;
-#else
             if (!Path.IsPathRooted(path))
             {
                 throw new ArgumentException("Path must be absolute", nameof(path));
@@ -54,10 +47,8 @@ namespace GitCredentialManager.Interop.Posix
             }
 
             return Path.Combine("/", partialPath);
-#endif
         }
 
-#if !NETFRAMEWORK
         private static bool TryResolveFileLink(string path, out string target)
         {
             FileSystemInfo fsi = File.ResolveLinkTarget(path, true);
@@ -71,6 +62,5 @@ namespace GitCredentialManager.Interop.Posix
             target = fsi?.FullName;
             return fsi != null;
         }
-#endif
     }
 }

--- a/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
+++ b/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
@@ -1,12 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
+using System.Runtime.Versioning;
 using System.Text;
 
 namespace GitCredentialManager.Interop.Windows
 {
+    [SupportedOSPlatform("windows")]
     public class WindowsEnvironment : EnvironmentBase
     {
         public WindowsEnvironment(IFileSystem fileSystem)

--- a/src/shared/Core/Interop/Windows/WindowsFileSystem.cs
+++ b/src/shared/Core/Interop/Windows/WindowsFileSystem.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
+using System.Runtime.Versioning;
 
 namespace GitCredentialManager.Interop.Windows
 {
+    [SupportedOSPlatform("windows")]
     public class WindowsFileSystem : FileSystem
     {
         public override bool IsSamePath(string a, string b)

--- a/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
+++ b/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
@@ -1,5 +1,8 @@
+using System.Runtime.Versioning;
+
 namespace GitCredentialManager.Interop.Windows;
 
+[SupportedOSPlatform("windows")]
 public class WindowsProcessManager : ProcessManager
 {
     public WindowsProcessManager(ITrace2 trace2) : base(trace2)

--- a/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
+++ b/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Windows.Native;
 
 namespace GitCredentialManager.Interop.Windows
 {
+    [SupportedOSPlatform("windows")]
     public class WindowsSessionManager : SessionManager
     {
         public WindowsSessionManager(ITrace trace, IEnvironment env, IFileSystem fs) : base(trace, env, fs)

--- a/src/shared/Core/Interop/Windows/WindowsSettings.cs
+++ b/src/shared/Core/Interop/Windows/WindowsSettings.cs
@@ -21,7 +21,6 @@ namespace GitCredentialManager.Interop.Windows
         {
             value = null;
 
-#if NETFRAMEWORK
             // Check for machine (HKLM) registry keys that match the Git configuration name.
             // These can be set by system administrators via Group Policy, so make useful defaults.
             using (Microsoft.Win32.RegistryKey configKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(Constants.WindowsRegistry.HKConfigurationPath))
@@ -48,9 +47,6 @@ namespace GitCredentialManager.Interop.Windows
 
                 return true;
             }
-#else
-            return base.TryGetExternalDefault(section, scope, property, out value);
-#endif
         }
     }
 }

--- a/src/shared/Core/Interop/Windows/WindowsSettings.cs
+++ b/src/shared/Core/Interop/Windows/WindowsSettings.cs
@@ -1,9 +1,11 @@
+using System.Runtime.Versioning;
 
 namespace GitCredentialManager.Interop.Windows
 {
     /// <summary>
     /// Reads settings from Git configuration, environment variables, and defaults from the Windows Registry.
     /// </summary>
+    [SupportedOSPlatform("windows")]
     public class WindowsSettings : Settings
     {
         private readonly ITrace _trace;

--- a/src/shared/Core/Interop/Windows/WindowsTerminal.cs
+++ b/src/shared/Core/Interop/Windows/WindowsTerminal.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 using GitCredentialManager.Interop.Windows.Native;
 using Microsoft.Win32.SafeHandles;
@@ -9,6 +10,7 @@ namespace GitCredentialManager.Interop.Windows
     /// <summary>
     /// Represents a thin wrapper around the Windows console device.
     /// </summary>
+    [SupportedOSPlatform("windows")]
     public class WindowsTerminal : ITerminal
     {
         // ReadConsole 32768 fail, 32767 OK @linquize [https://github.com/Microsoft/Git-Credential-Manager-for-Windows/commit/a62b9a19f430d038dcd85a610d97e5f763980f85]

--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -31,7 +31,6 @@ namespace GitCredentialManager
                 return false;
             }
 
-#if NETFRAMEWORK
             // Check for machine (HKLM) registry keys for Cloud PC indicators
             // Note that the keys are only found in the 64-bit registry view
             using (Microsoft.Win32.RegistryKey hklm64 = Microsoft.Win32.RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine, Microsoft.Win32.RegistryView.Registry64))
@@ -48,9 +47,6 @@ namespace GitCredentialManager
 
                 return w365Value is not null && Guid.TryParse(partnerValue, out Guid partnerId) && partnerId == Constants.DevBoxPartnerId;
             }
-#else
-            return false;
-#endif
         }
 
         /// <summary>
@@ -79,8 +75,9 @@ namespace GitCredentialManager
             // Implementation of version checking was taken from:
             // https://github.com/dotnet/runtime/blob/6578f257e3be2e2144a65769706e981961f0130c/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs#L110-L122
             //
-            // Note that we cannot use Environment.OSVersion in .NET Framework (or Core versions less than 5.0) as
-            // the implementation in those versions "lies" about Windows versions > 8.1 if there is no application manifest.
+            // Note that we cannot use Environment.OSVersion because we also need
+            // to know the product type (client vs server) to determine the minimum
+            // build number for WAM support.
             if (RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi) != 0)
             {
                 return false;
@@ -197,11 +194,9 @@ namespace GitCredentialManager
         {
             if (IsWindows())
             {
-#if NETFRAMEWORK
                 var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
                 var principal = new System.Security.Principal.WindowsPrincipal(identity);
                 return principal.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
-#endif
             }
             else if (IsPosix())
             {
@@ -287,9 +282,6 @@ namespace GitCredentialManager
                 }
             }
 
-#if NETFRAMEWORK
-            return null;
-#else
             //
             // We cannot determine the absolute file path from argv[0]
             // (how we were launched), so let's now try to extract the
@@ -299,7 +291,6 @@ namespace GitCredentialManager
             //
             FileSystemInfo fsi = File.ResolveLinkTarget("/proc/self/exe", returnFinalTarget: false);
             return fsi?.FullName;
-#endif
         }
 
         private static string GetMacOSEntryPath()
@@ -364,16 +355,6 @@ namespace GitCredentialManager
             // return the correct version on Windows & macOS, rather than the manifested
             // version for Windows or the kernel version for macOS.
             // https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version
-            //
-            // However, we still need to use the old method for Windows on .NET Framework
-            // and call into the Win32 API to get the correct version (regardless of app
-            // compatibility settings).
-#if NETFRAMEWORK
-            if (IsWindows() && RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi) == 0)
-            {
-                return $"{osvi.dwMajorVersion}.{osvi.dwMinorVersion} (build {osvi.dwBuildNumber})";
-            }
-#endif
             if (IsWindows() || IsMacOS())
             {
                 return Environment.OSVersion.Version.ToString();

--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Posix.Native;
 
 namespace GitCredentialManager
@@ -110,33 +110,38 @@ namespace GitCredentialManager
         /// Check if the current Operating System is macOS.
         /// </summary>
         /// <returns>True if running on macOS, false otherwise.</returns>
+        [SupportedOSPlatformGuard("macos")]
         public static bool IsMacOS()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            return OperatingSystem.IsMacOS();
         }
 
         /// <summary>
         /// Check if the current Operating System is Windows.
         /// </summary>
         /// <returns>True if running on Windows, false otherwise.</returns>
+        [SupportedOSPlatformGuard("windows")]
         public static bool IsWindows()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return OperatingSystem.IsWindows();
         }
 
         /// <summary>
         /// Check if the current Operating System is Linux-based.
         /// </summary>
         /// <returns>True if running on a Linux distribution, false otherwise.</returns>
+        [SupportedOSPlatformGuard("linux")]
         public static bool IsLinux()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            return OperatingSystem.IsLinux();
         }
 
         /// <summary>
         /// Check if the current Operating System is POSIX-compliant.
         /// </summary>
         /// <returns>True if running on a POSIX-compliant Operating System, false otherwise.</returns>
+        [SupportedOSPlatformGuard("macos")]
+        [SupportedOSPlatformGuard("linux")]
         public static bool IsPosix()
         {
             return IsMacOS() || IsLinux();

--- a/src/shared/Core/UI/AvaloniaUi.cs
+++ b/src/shared/Core/UI/AvaloniaUi.cs
@@ -65,22 +65,15 @@ namespace GitCredentialManager.UI
                 {
                     var appBuilder = AppBuilder.Configure<AvaloniaApp>();
 
-#if NETFRAMEWORK
                     // Set custom rendering options and modes if required
                     if (PlatformUtils.IsWindows() && _win32SoftwareRendering)
                     {
                         appBuilder.With(new Win32PlatformOptions
                             { RenderingMode = new[] { Win32RenderingMode.Software } });
                     }
-#endif
 
                     appBuilder
-#if NETFRAMEWORK
-                        .UseWin32()
-                        .UseSkia()
-#else
                         .UsePlatformDetect()
-#endif
                         .LogToTrace()
                         .SetupWithoutStarting();
 

--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net472;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64;osx-x64;linux-x64;osx-arm64;linux-arm64;linux-arm</RuntimeIdentifiers>
     <AssemblyName>git-credential-manager</AssemblyName>
     <RootNamespace>GitCredentialManager</RootNamespace>

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -76,12 +76,7 @@ namespace GitCredentialManager
         // Required for Avalonia designer
         static AppBuilder BuildAvaloniaApp() =>
             AppBuilder.Configure<AvaloniaApp>()
-#if NETFRAMEWORK
-                .UseWin32()
-                .UseSkia()
-#else
                 .UsePlatformDetect()
-#endif
                 .LogToTrace();
     }
 }

--- a/src/shared/GitHub/GitHub.csproj
+++ b/src/shared/GitHub/GitHub.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net10.0;net472</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>GitHub</AssemblyName>
     <RootNamespace>GitHub</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -11,10 +10,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/src/shared/GitLab/GitLab.csproj
+++ b/src/shared/GitLab/GitLab.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net10.0;net472</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>GitLab</AssemblyName>
     <RootNamespace>GitLab</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -11,10 +10,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/src/shared/Microsoft.AzureRepos/Microsoft.AzureRepos.csproj
+++ b/src/shared/Microsoft.AzureRepos/Microsoft.AzureRepos.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net10.0;net472</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Microsoft.AzureRepos</AssemblyName>
     <RootNamespace>Microsoft.AzureRepos</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -11,10 +10,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/src/windows/Installer.Windows/Installer.Windows.csproj
+++ b/src/windows/Installer.Windows/Installer.Windows.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <PayloadPath>$(PlatformOutPath)Installer.Windows\bin\$(Configuration)\net472\$(RuntimeIdentifier)\</PayloadPath>
+    <PayloadPath>$(PlatformOutPath)Installer.Windows\bin\$(Configuration)\net10.0\$(RuntimeIdentifier)\</PayloadPath>
     <!-- We already append the RID to our intermediate PayloadPath and also to the
          final installer filenames so there's no need to append to the output path. -->
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>

--- a/src/windows/Installer.Windows/layout.ps1
+++ b/src/windows/Installer.Windows/layout.ps1
@@ -67,7 +67,6 @@ mkdir -p "$PAYLOAD","$SYMBOLS" | Out-Null
 # Publish core application executables
 Write-Output "Publishing core application..."
 dotnet publish "$GCM_SRC" `
-	--framework net472 `
 	--configuration "$Configuration" `
 	--runtime $RuntimeIdentifier `
 	--output "$PAYLOAD"


### PR DESCRIPTION
## Summary

Git Credential Manager no longer targets .NET Framework. This drops the `net472` TFM everywhere, leaving `net10.0` as the single target on all platforms (Windows included), then deletes the code that only existed to support the old runtime and tightens our OS-platform guarantees.

## Why

The product builds against the CoreCLR on every platform now. The .NET Framework target only added a second build pivot, a pile of conditional code, and Windows-only baggage. Collapsing to one modern TFM simplifies the build, the source, and everything downstream (packaging, CI, trimming/AOT work that follows).

## What changes

- **Drop `net472` from all projects and build scripts.** Windows now builds the single `net10.0` TFM like every other platform.
- **Remove dead `#if NETFRAMEWORK` code.** With only the CoreCLR left, this code was unreachable.
- **Add `[SupportedOSPlatform]` attributes** to OS-specific types so use of platform-specific behaviour is gated at compile time.
- **Suppress CA1416 in test projects.** Our xUnit attributes (`[WindowsFact]`, `[PosixFact]`, …) skip OS-specific tests at runtime; the analyzer can't see that, so the warning is noise in tests.

## Caveat

Removing the .NET Framework target also removes the **embedded web view** for Microsoft authentication — a netfx-only, Windows-only feature. The goal will be to move to the Windows "WAM" broker by default before release to replace the UX offered by embedded wv.